### PR TITLE
Create a vendor folder

### DIFF
--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -4,39 +4,44 @@ const babel = require('gulp-babel');
 var sass = require('gulp-sass');
 var inject = require('gulp-inject');
 var clean = require('gulp-clean');
+var gnf = require('gulp-npm-files');
 
 var destination = 'dist/web/';
 
 gulp.task('sass', function () {
-    return gulp.src('src/scss/**/*.scss')
-        .pipe(sourcemaps.init())
-        .pipe(sass().on('error', sass.logError))
-        .pipe(sourcemaps.write())
-        .pipe(gulp.dest(destination + 'css'));
+  return gulp.src('src/scss/**/*.scss')
+             .pipe(sourcemaps.init())
+             .pipe(sass().on('error', sass.logError))
+             .pipe(sourcemaps.write())
+             .pipe(gulp.dest(destination + 'css'));
 });
 
 gulp.task('javascript', function() {
-    return gulp.src('src/javascript/**/*.js')
-        .pipe(sourcemaps.init())
-        .pipe(babel({
-            plugins: ['transform-runtime'],
-            presets: ['es2015']
-        }))
-        .pipe(sourcemaps.write('.'))
-        .pipe(gulp.dest(destination + 'javascript'));
+  return gulp.src('src/javascript/**/*.js')
+             .pipe(sourcemaps.init())
+             .pipe(babel({
+               plugins: ['transform-runtime'],
+               presets: ['es2015']
+             }))
+             .pipe(sourcemaps.write('.'))
+             .pipe(gulp.dest(destination + 'javascript'));
 });
 
-gulp.task('html', ['javascript', 'sass'], function() {
-    var target = gulp.src('src/index.html');
-    var sources = gulp.src(['./dist/javascript/**/*.js', './dist/css/**/*.css'], {read: false});
+gulp.task('vendor', function() {
+  gulp.src(gnf(), {base:'./node_modules/'}).pipe(gulp.dest(destination + 'vendor'));
+});
 
-    return target.pipe(inject(sources))
-        .pipe(gulp.dest(destination));
+gulp.task('html', ['javascript', 'vendor', 'sass'], function() {
+  var target = gulp.src('src/index.html');
+  var sources = gulp.src([destination + 'javascript/**/*.js', destination + 'css/**/*.css'], {read: false});
+
+  return target.pipe(inject(sources))
+               .pipe(gulp.dest(destination));
 });
 
 gulp.task('clean', function () {
-    return gulp.src('dist/*', {read: false})
-        .pipe(clean());
+  return gulp.src('dist/*', {read: false})
+             .pipe(clean());
 });
 
 gulp.task('default', ['html']);

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,11 @@
     "gulp-babel": "^6.1.2",
     "gulp-clean": "^0.3.2",
     "gulp-inject": "^4.1.0",
+    "gulp-npm-files": "^0.1.3",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0"
+  },
+  "dependencies": {
+    "jquery": "^3.1.1"
   }
 }


### PR DESCRIPTION
All dependecies in `package.json` will be exported to a `vendor` folder. I could try to automatically import them, but I was tired of playing with configs.