### PR TITLE
Read Game State From Controllers

### DIFF
--- a/game/src/main/scala/ScalatraBootstrap.scala
+++ b/game/src/main/scala/ScalatraBootstrap.scala
@@ -7,6 +7,7 @@ import slick.driver.H2Driver.api._
 
 class ScalatraBootstrap extends LifeCycle {
   val cpds = new ComboPooledDataSource
+  val game = new GameThread
 
   override def init(context: ServletContext): Unit = {
     launchGameLoop
@@ -27,6 +28,6 @@ class ScalatraBootstrap extends LifeCycle {
   }
 
   def launchGameLoop {
-    new Thread(new GameThread).start
+    new Thread(game).start
   }
 }

--- a/game/src/main/scala/ScalatraBootstrap.scala
+++ b/game/src/main/scala/ScalatraBootstrap.scala
@@ -15,7 +15,7 @@ class ScalatraBootstrap extends LifeCycle {
     val path = "/api/1"
     val db = Database.forDataSource(cpds)
     context.mount(new LeaderboardController, s"$path/leaderboard/*")
-    context.mount(new GameController, s"$path/game/*")
+    context.mount(new GameController(game), s"$path/game/*")
   }
 
   private def closeDbConnection() {

--- a/game/src/main/scala/io/aigar/controller/AigarStack.scala
+++ b/game/src/main/scala/io/aigar/controller/AigarStack.scala
@@ -14,6 +14,10 @@ trait AigarStack extends ScalatraServlet with ScalateSupport with JacksonJsonSup
     contentType = formats("json")
   }
 
+  trap(400) {
+    returnError(400, "invalid request")
+  }
+
   trap(404) {
     returnError(404, "not found")
   }

--- a/game/src/main/scala/io/aigar/controller/GameController.scala
+++ b/game/src/main/scala/io/aigar/controller/GameController.scala
@@ -6,7 +6,7 @@ import org.json4s.{DefaultFormats, Formats, MappingException}
 import org.scalatra.json._
 import scala.util.Try
 
-class GameController(val game: GameThread)
+class GameController(game: GameThread)
   extends AigarStack with JacksonJsonSupport {
 
   get("/:id") {

--- a/game/src/main/scala/io/aigar/controller/GameController.scala
+++ b/game/src/main/scala/io/aigar/controller/GameController.scala
@@ -4,16 +4,20 @@ import io.aigar.game._
 import io.aigar.controller.response._
 import org.json4s.{DefaultFormats, Formats, MappingException}
 import org.scalatra.json._
+import scala.util.Try
 
-class GameController extends AigarStack with JacksonJsonSupport {
+class GameController(val game: GameThread)
+  extends AigarStack with JacksonJsonSupport {
+
   get("/:id") {
     GameStateResponse(
-      // TODO get from GameThread
-      halt(404)
-      // GameStates.all find (_.id.toString() == params("id")) match {
-      //   case Some(b) => b
-      //   case None => halt(404)
-      // }
+      Try(params("id").toInt).toOption match {
+        case Some(id) => game.gameState(id) match {
+          case Some(state) => state
+          case None => halt(404)
+        }
+        case None => halt(400)
+      }
     )
   }
 

--- a/game/src/main/scala/io/aigar/controller/GameController.scala
+++ b/game/src/main/scala/io/aigar/controller/GameController.scala
@@ -1,32 +1,19 @@
 package io.aigar.controller
 
+import io.aigar.game._
 import io.aigar.controller.response._
 import org.json4s.{DefaultFormats, Formats, MappingException}
 import org.scalatra.json._
 
 class GameController extends AigarStack with JacksonJsonSupport {
-  object GameStates {
-    var all = List(
-      GameState(
-        1,
-        5,
-        List(
-          Player(12, "such", 555, List(Cell(5, 5, Position(10,10), Position(10, 10)))),
-          Player(13, "wow", 555, List[Cell]())
-        ),
-        Food(List(Position(5,5)), List[Position](), List[Position]()),
-        Dimensions(10, 10),
-        List[Position]()
-      )
-    )
-  }
-
   get("/:id") {
     GameStateResponse(
-      GameStates.all find (_.id.toString() == params("id")) match {
-        case Some(b) => b
-        case None => halt(404)
-      }
+      // TODO get from GameThread
+      halt(404)
+      // GameStates.all find (_.id.toString() == params("id")) match {
+      //   case Some(b) => b
+      //   case None => halt(404)
+      // }
     )
   }
 

--- a/game/src/main/scala/io/aigar/controller/GameResponse.scala
+++ b/game/src/main/scala/io/aigar/controller/GameResponse.scala
@@ -1,40 +1,8 @@
 package io.aigar.controller.response
+import io.aigar.game._
 
 case class ErrorResponse(error: String)
 
-case class Position(
-  x: Float,
-  y: Float
-)
-case class Dimensions(
-  width: Int,
-  height: Int
-)
-case class Cell(
-  id: Int,
-  mass: Int,
-  position: Position,
-  target: Position
-)
-case class Player(
-  id: Int,
-  name: String,
-  total_mass: Integer,
-  cells: List[Cell]
-)
-case class Food(
-  regular: List[Position],
-  silver: List[Position],
-  gold: List[Position]
-)
-case class GameState(
-  id: Int,
-  tick: Int,
-  players: List[Player],
-  food: Food,
-  map: Dimensions,
-  viruses: List[Position]
-)
 case class GameStateResponse(data: GameState)
 
 case class GameCreation(id: Int, url: String)

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -5,7 +5,7 @@ package io.aigar.game
  * (e.g. the ranked game or a private test game).
  */
 object Game {
-  val RankedGameId = 0
+  final val RankedGameId = 0
 }
 
 class Game(val id: Int) {

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -1,0 +1,30 @@
+package io.aigar.game
+
+/**
+ * Game holds the logic for an individual game being played
+ * (e.g. the ranked game or a private test game).
+ */
+object Game {
+  val RankedGameId = 0
+}
+
+class Game(val id: Int) {
+  def update {
+    //TODO implement
+  }
+
+  def state = {
+    //TODO really implement
+    GameState(
+        1,
+        5,
+        List(
+          Player(12, "such", 555, List(Cell(5, 5, Position(10,10), Position(10, 10)))),
+          Player(13, "wow", 555, List[Cell]())
+        ),
+        Food(List(Position(5,5)), List[Position](), List[Position]()),
+        Dimensions(10, 10),
+        List[Position]()
+      )
+  }
+}

--- a/game/src/main/scala/io/aigar/game/GameState.scala
+++ b/game/src/main/scala/io/aigar/game/GameState.scala
@@ -1,0 +1,41 @@
+package io.aigar.game
+
+/**
+ * Serializable classes that represent the current state of a game. These are
+ * the classes that will be sent over the network, so they should follow the
+ * conventions in the API.
+ */
+
+case class Position(
+  x: Float,
+  y: Float
+)
+case class Dimensions(
+  width: Int,
+  height: Int
+)
+case class Cell(
+  id: Int,
+  mass: Int,
+  position: Position,
+  target: Position
+)
+case class Player(
+  id: Int,
+  name: String,
+  total_mass: Integer,
+  cells: List[Cell]
+)
+case class Food(
+  regular: List[Position],
+  silver: List[Position],
+  gold: List[Position]
+)
+case class GameState(
+  id: Int,
+  tick: Int,
+  players: List[Player],
+  food: Food,
+  map: Dimensions,
+  viruses: List[Position]
+)

--- a/game/src/main/scala/io/aigar/game/GameState.scala
+++ b/game/src/main/scala/io/aigar/game/GameState.scala
@@ -3,7 +3,7 @@ package io.aigar.game
 /**
  * Serializable classes that represent the current state of a game. These are
  * the classes that will be sent over the network, so they should follow the
- * conventions in the API.
+ * conventions of the API.
  */
 
 case class Position(

--- a/game/src/main/scala/io/aigar/game/GameThread.scala
+++ b/game/src/main/scala/io/aigar/game/GameThread.scala
@@ -8,13 +8,13 @@ package io.aigar.game
 class GameThread extends Runnable {
   val MillisecondsPerTick = 16
 
-  private var _states: Map[Int, GameState] = Map()
-  private var _games: List[Game] = List(createRankedGame)
+  private var states: Map[Int, GameState] = Map()
+  private var games: List[Game] = List(createRankedGame)
 
   /**
    * Safe way to get the game state of a particular game from another thread.
    */
-  def gameState(gameId: Int) = { _states get gameId }
+  def gameState(gameId: Int) = { states get gameId }
 
   def createRankedGame = {
     new Game(Game.RankedGameId)
@@ -29,10 +29,10 @@ class GameThread extends Runnable {
   }
 
   def updateGames {
-    for (game <- _games) {
+    for (game <- games) {
       game.update
 
-      _states = _states + (game.id -> game.state)
+      states = states + (game.id -> game.state)
     }
   }
 }

--- a/game/src/main/scala/io/aigar/game/GameThread.scala
+++ b/game/src/main/scala/io/aigar/game/GameThread.scala
@@ -6,7 +6,33 @@ package io.aigar.game
  * of the players.
  */
 class GameThread extends Runnable {
+  val MillisecondsPerTick = 16
+
+  private var _states: Map[Int, GameState] = Map()
+  private var _games: List[Game] = List(createRankedGame)
+
+  /**
+   * Safe way to get the game state of a particular game from another thread.
+   */
+  def gameState(gameId: Int) = { _states get gameId }
+
+  def createRankedGame = {
+    new Game(Game.RankedGameId)
+  }
+
   def run {
-    println("TODO Game loop")
+    while (true) {
+      updateGames
+
+      Thread.sleep(MillisecondsPerTick)
+    }
+  }
+
+  def updateGames {
+    for (game <- _games) {
+      game.update
+
+      _states = _states + (game.id -> game.state)
+    }
   }
 }

--- a/game/src/test/scala/io/aigar/controller/AigarStackSpec.scala
+++ b/game/src/test/scala/io/aigar/controller/AigarStackSpec.scala
@@ -34,5 +34,13 @@ class AigarStackSpec extends MutableScalatraSpec {
         result must_==("unprocessable entity")
       }
     }
+
+    "400 should return a generic error" in {
+      get("/400") {
+        status must_== 400
+        val result = parse(body).extract[ErrorResponse].error
+        result must_==("invalid request")
+      }
+    }
   }
 }

--- a/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
+++ b/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
@@ -44,12 +44,28 @@ class GameControlleSpec extends MutableScalatraSpec with JsonMatchers {
       )
     )
 
-  "GET / on the ranked game on GameController" should {
+  "GET /{the ranked game} on GameController" should {
     "return a parsable GameStateResponse" in {
       get("/" + Game.RankedGameId.toString) {
         status must_== 200
 
         parse(body).extract[GameStateResponse] must not(throwAn[MappingException])
+      }
+    }
+  }
+
+  "GET /hello on GameController" should {
+    "fail with a bad request (invalid ID)" in {
+      get("/hello") {
+        status must_== 400
+      }
+    }
+  }
+
+  "GET /1337 (invalid ID) on GameController" should {
+    "fail with a not found error" in {
+      get("/1337") {
+        status must_== 404
       }
     }
   }

--- a/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
+++ b/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
@@ -1,3 +1,4 @@
+import io.aigar.game._
 import io.aigar.controller._
 import io.aigar.controller.response._
 
@@ -11,7 +12,10 @@ import org.specs2.matcher._
 class GameControlleSpec extends MutableScalatraSpec with JsonMatchers {
   implicit val jsonFormats: Formats = DefaultFormats
 
-  addServlet(classOf[GameController], "/*")
+  val game = new GameThread
+  game.updateGames // run once to initialize the game states
+
+  addServlet(new GameController(game), "/*")
 
   def postJson[A](uri: String, body: JValue, headers: Map[String, String] = Map())(f: => A): A =
     post(
@@ -40,9 +44,9 @@ class GameControlleSpec extends MutableScalatraSpec with JsonMatchers {
       )
     )
 
-  "GET /:id on GameController" should {
+  "GET / on the ranked game on GameController" should {
     "return a parsable GameStateResponse" in {
-      get("/1") {
+      get("/" + Game.RankedGameId.toString) {
         status must_== 200
 
         parse(body).extract[GameStateResponse] must not(throwAn[MappingException])

--- a/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
+++ b/game/src/test/scala/io/aigar/controller/GameControllerSpec.scala
@@ -46,7 +46,7 @@ class GameControlleSpec extends MutableScalatraSpec with JsonMatchers {
 
   "GET /{the ranked game} on GameController" should {
     "return a parsable GameStateResponse" in {
-      get("/" + Game.RankedGameId.toString) {
+      get("/" + Game.RankedGameId) {
         status must_== 200
 
         parse(body).extract[GameStateResponse] must not(throwAn[MappingException])


### PR DESCRIPTION
This PR adds a game loop (`while true`) to `GameThread` that sleeps and constantly `update`s its `Game` objects and saves their `state`s (always regenerating them in an immutable data structure for thread safety). The controller then accesses it through the `gameState` method.

I couldn't find exactly whether this approach is thread safe or not (immutable != thread safe in scala, from what I've read), but I don't see why it wouldn't be -- we have *one* writer thread that constantly changes the pointer to the game states, and pointer assignment [*is* atomic](http://stackoverflow.com/a/11129010/395386). The controller threads are reading from this `Map` every once in a while. Now, "don't see why" doesn't feel good when we're talking about thread-safety... so if someone wants to read more on the subject just to be sure, please do.

I did not add tests for `GameThread` in this PR, as I believe it with require a tiny bit of configuration (I didn't want to mix the PR with other stuff). Created #62 for this.


Closes #49 #15 .