### PR TITLE
Game Unit Tests & Integration Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 notifications:
   email: false
 
-script: cd game && sbt clean test
+script: cd game && sbt clean test it:test

--- a/game/project/build.scala
+++ b/game/project/build.scala
@@ -13,44 +13,51 @@ object AigarBuild extends Build {
   val ScalaVersion = "2.11.8"
   val ScalatraVersion = "2.4.1"
 
-  lazy val project = Project (
-    "aigar",
-    file("."),
-    settings = ScalatraPlugin.scalatraSettings ++ scalateSettings ++ Seq(
+  lazy val project = Project ("aigar", file("."))
+    .configs(IntegrationTest)
+    .settings(ScalatraPlugin.scalatraSettings)
+    .settings(scalateSettings)
+    .settings(Defaults.itSettings : _*)
+    .settings(projectSettings)
+    .enablePlugins(JettyPlugin)
+
+  lazy val projectSettings = Seq(
       organization := Organization,
       name := Name,
       version := Version,
       scalaVersion := ScalaVersion,
       resolvers += Classpaths.typesafeReleases,
       resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
-      libraryDependencies ++= Seq(
-        "org.scalatra" %% "scalatra" % ScalatraVersion,
-        "org.scalatra" %% "scalatra-scalate" % ScalatraVersion,
-        "org.scalatra" %% "scalatra-specs2" % ScalatraVersion % "test",
-        "org.slf4j" % "slf4j-api" % "1.7.13" % "provided",
-        "org.slf4j" % "slf4j-nop" % "1.7.13" % "test",
-        "org.eclipse.jetty" % "jetty-webapp" % "9.2.15.v20160210" % "container",
-        "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
-        "org.json4s" %% "json4s-jackson" % "3.3.0.RC2",
-        "org.scalatra" %% "scalatra-json" % "2.4.0-RC2-2",
-        "com.typesafe.slick" %% "slick" % "3.1.1",
-        "com.h2database" % "h2" % "1.4.192",
-        "com.mchange" % "c3p0" % "0.9.5.1",
-        "org.scalactic" %% "scalactic" % "3.0.0",
-        "org.scalatest" %% "scalatest" % "3.0.0" % "test"
-      ),
-      scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
-        Seq(
-          TemplateConfig(
-            base / "webapp" / "WEB-INF" / "templates",
-            Seq.empty,  /* default imports should be added here */
-            Seq(
-              Binding("context", "_root_.org.scalatra.scalate.ScalatraRenderContext", importMembers = true, isImplicit = true)
-            ),  /* add extra bindings here */
-            Some("templates")
-          )
+      libraryDependencies ++= deps,
+      scalateTemplates)
+
+  lazy val deps = Seq(
+    "org.scalatra" %% "scalatra" % ScalatraVersion,
+    "org.scalatra" %% "scalatra-scalate" % ScalatraVersion,
+    "org.scalatra" %% "scalatra-specs2" % ScalatraVersion % "test,it",
+    "org.slf4j" % "slf4j-api" % "1.7.13" % "provided",
+    "org.slf4j" % "slf4j-nop" % "1.7.13" % "test,it",
+    "org.eclipse.jetty" % "jetty-webapp" % "9.2.15.v20160210" % "container",
+    "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
+    "org.json4s" %% "json4s-jackson" % "3.3.0.RC2",
+    "org.scalatra" %% "scalatra-json" % "2.4.0-RC2-2",
+    "com.typesafe.slick" %% "slick" % "3.1.1",
+    "com.h2database" % "h2" % "1.4.192",
+    "com.mchange" % "c3p0" % "0.9.5.1",
+    "org.scalactic" %% "scalactic" % "3.0.0",
+    "org.scalatest" %% "scalatest" % "3.0.0" % "test,it"
+      )
+  lazy val scalateTemplates =
+    scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
+      Seq(
+        TemplateConfig(
+          base / "webapp" / "WEB-INF" / "templates",
+          Seq.empty,  /* default imports should be added here */
+         Seq(
+           Binding("context", "_root_.org.scalatra.scalate.ScalatraRenderContext", importMembers = true, isImplicit = true)
+         ),  /* add extra bindings here */
+        Some("templates")
         )
-      }
-    )
-  ).enablePlugins(JettyPlugin)
+      )
+    }
 }

--- a/game/project/build.scala
+++ b/game/project/build.scala
@@ -35,7 +35,9 @@ object AigarBuild extends Build {
         "org.scalatra" %% "scalatra-json" % "2.4.0-RC2-2",
         "com.typesafe.slick" %% "slick" % "3.1.1",
         "com.h2database" % "h2" % "1.4.192",
-        "com.mchange" % "c3p0" % "0.9.5.1"
+        "com.mchange" % "c3p0" % "0.9.5.1",
+        "org.scalactic" %% "scalactic" % "3.0.0",
+        "org.scalatest" %% "scalatest" % "3.0.0" % "test"
       ),
       scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
         Seq(

--- a/game/src/it/scala/ScalatraBootstrapSpec.scala
+++ b/game/src/it/scala/ScalatraBootstrapSpec.scala
@@ -1,0 +1,24 @@
+import io.aigar.controller._
+import io.aigar.controller.response._
+import io.aigar.game._
+
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
+import org.scalatra.test.specs2._
+import org.specs2.matcher._
+
+class ScalatraBootstrapSpec extends WholeAppTest {
+  protected implicit val jsonFormats: Formats = DefaultFormats
+
+  "GET /{ranked game} on the API" should {
+    "successfully return a game state with the right ID" in {
+      get("/api/1/game/" + Game.RankedGameId.toString) {
+        status must be_==(200).eventually
+
+        val state = parse(body).extract[GameStateResponse].data
+        state.id must be_==(Game.RankedGameId)
+      }
+    }
+  }
+}

--- a/game/src/it/scala/ScalatraBootstrapSpec.scala
+++ b/game/src/it/scala/ScalatraBootstrapSpec.scala
@@ -11,8 +11,8 @@ import org.specs2.matcher._
 class ScalatraBootstrapSpec extends WholeAppTest {
   protected implicit val jsonFormats: Formats = DefaultFormats
 
-  "GET /{ranked game} on the API" should {
-    "successfully return a game state with the right ID" in {
+  "Launching the whole application" should {
+    "launch a game thread that sets the state of the ranked game" in {
       get("/api/1/game/" + Game.RankedGameId.toString) {
         status must be_==(200).eventually
 

--- a/game/src/it/scala/WholeAppTest.scala
+++ b/game/src/it/scala/WholeAppTest.scala
@@ -1,0 +1,14 @@
+import org.scalatra.test.specs2._
+import org.scalatra.servlet._
+import org.eclipse.jetty.servlet._
+
+// https://github.com/scalatra/scalatra/issues/340#issuecomment-52962174
+class WholeAppTest extends MutableScalatraSpec {
+  override lazy val servletContextHandler = {
+    val handler = new ServletContextHandler(ServletContextHandler.SESSIONS)
+    handler.setContextPath(contextPath)
+    handler.addEventListener(new ScalatraListener)
+    handler.setResourceBase(resourceBasePath)
+    handler
+  }
+}

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -16,7 +16,7 @@ class Game(val id: Int) {
   def state = {
     //TODO really implement
     GameState(
-        1,
+        id,
         5,
         List(
           Player(12, "such", 555, List(Cell(5, 5, Position(10,10), Position(10, 10)))),

--- a/game/src/test/scala/io/aigar/game/GameSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameSpec.scala
@@ -1,0 +1,10 @@
+import io.aigar.game._
+import org.scalatest._
+
+class GameSpec extends FlatSpec with Matchers {
+  "A Game" should "generate a new state object every time (thread-safety)" in {
+    val game = new Game(42)
+    val state1 = game.state
+    game.state should not be theSameInstanceAs(state1)
+  }
+}

--- a/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
@@ -23,6 +23,6 @@ class GameThreadSpec extends FlatSpec with Matchers {
   it should "create a ranked game with the right ID" in {
     val game = new GameThread
     val ranked = game.createRankedGame
-    ranked.id should equal Game.RankedGameId
+    ranked.id should equal (Game.RankedGameId)
   }
 }

--- a/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
@@ -1,0 +1,28 @@
+import io.aigar.game._
+import org.scalatest._
+
+
+class GameThreadSpec extends FlatSpec with Matchers {
+  "A GameThread" should "not have a ranked game state at first" in {
+    val game = new GameThread
+    game.gameState(Game.RankedGameId) shouldBe None
+  }
+
+  it should "have a ranked game state after a game update" in {
+    val game = new GameThread
+    game.updateGames
+    game.gameState(Game.RankedGameId) shouldBe defined
+  }
+
+  it should "not have a game with a bad ID" in {
+    val game = new GameThread
+    game.updateGames
+    game.gameState(1337) shouldBe empty
+  }
+  
+  it should "create a ranked game with the right ID" in {
+    val game = new GameThread
+    val ranked = game.createRankedGame
+    ranked.id should equal Game.RankedGameId
+  }
+}


### PR DESCRIPTION
# Please review #63 first. This PR is based on this branch for simplicity.

Couple of small things:
- Add `ScalaTest` dependency
- Test `GameThread`: making sure that the state gets updated and that we can get the state of the ranked game
- Test `Game`: making sure that it *generates* states, not store them (thread-safety)
- Add `WholeApp`: takes care of doing the bootstrapping work so that we can then run tests on the whole server
- Refactor `build.scala`: was messy to add integration test setup otherwise
- Add integration test setup in `build.scala` (note: looks like the convention for `sbt` is to use `it` for integration tests, call with `sbt it:test`)
- Add `ScalatraBootstrap` integration test in `it` folder: making sure that the `GameThread` is launched and updating the state of the ranked game
- Change `.travis.yml` to run integration tests

Closes #62 #64 .