### PR TITLE
Make sure that a cell does not move by default

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -17,7 +17,7 @@ object Cell {
 
 class Cell(id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
   var position = startPosition
-  var target = new Vector2(0f, 0f)
+  var target = startPosition
   var mass = Cell.MinMass
   private var _velocity = new Vector2(0f, 0f)
 

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -55,5 +55,13 @@ class CellSpec extends FlatSpec with Matchers {
     state.id should equal(1)
     state.mass should equal(100)
   }
+
+  it should "not move without setting its target" in {
+    val cell = new Cell(1, new Vector2(42f, 42f))
+    
+    cell.update(1f)
+
+    cell.position should equal(new Vector2(42f, 42f))
+  }
 }
 


### PR DESCRIPTION
This is the reason all the positions end up close to `(0,0)` on #91 .