### PR TITLE
Wandering behaviour (server AI)

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -19,6 +19,7 @@ class Cell(id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
   var position = startPosition
   var target = startPosition
   var mass = Cell.MinMass
+  var behavior: SteeringBehavior = new NoBehavior(this)
   private var _velocity = new Vector2(0f, 0f)
 
   /**
@@ -36,6 +37,8 @@ class Cell(id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
 
 
   def update(deltaSeconds: Float) {
+    target = behavior.update(deltaSeconds)
+
     velocity += acceleration * deltaSeconds
     position += velocity * deltaSeconds
   }

--- a/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
+++ b/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
@@ -39,7 +39,7 @@ class WanderingBehavior(cell: Cell) extends SteeringBehavior {
   def circleCenter = {
     val diff = cell.target - cell.position
     val dir = if (diff.magnitude > 0) diff.normalize else Vector2(0f, -1f)
-    dir * WanderingBehavior.CircleDistance
+    cell.position + dir * WanderingBehavior.CircleDistance
   }
 
   def displacementOnCircle = {

--- a/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
+++ b/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
@@ -54,7 +54,7 @@ object WanderingBehavior {
   final val CircleRadius = 10f
 
   // how much (radians) the wandering angle can shift per second
-  final val AngleChange = Pi.toFloat / 2f
+  final val AngleChange = Pi.toFloat / 4f
 }
 
 /**

--- a/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
+++ b/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
@@ -54,7 +54,7 @@ object WanderingBehavior {
   final val CircleRadius = 10f
 
   // how much (radians) the wandering angle can shift per second
-  final val AngleChange = Pi / 2f
+  final val AngleChange = Pi.toFloat / 2f
 }
 
 /**

--- a/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
+++ b/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
@@ -1,0 +1,67 @@
+package io.aigar.game
+
+import scala.util.Random
+import scala.math.{cos, sin, atan2, Pi}
+import com.github.jpbetz.subspace._
+
+/**
+ * Represents a movement behavior of an entity.
+ * This is used to make a cell move on its own (server AI).
+ */
+trait SteeringBehavior {
+  /**
+   * Determines what the next target of a cell should be.
+   */
+  def update(deltaSeconds: Float): Vector2
+}
+
+class WanderingBehavior(cell: Cell) extends SteeringBehavior {
+  val random = new Random
+  var wanderAngle = 0f
+
+  /**
+   * Picks a target that gives an illusion of "wandering around".
+   *
+   * The way that this behavior is implemented is that we imagine a "circle" in
+   * front of the entity and place our target on that circle. As we update the
+   * behavior, it randomly moves the target a bit along the circle.
+   * See: https://gamedevelopment.tutsplus.com/tutorials/understanding-steering-behaviors-wander--gamedev-1624
+   */
+  def update(deltaSeconds: Float) = {
+    val target = circleCenter + displacementOnCircle
+
+    val multiplier = random.nextFloat() * 0.5f
+    wanderAngle += multiplier * WanderingBehavior.AngleChange * deltaSeconds
+
+    target
+  }
+
+  def circleCenter = {
+    val diff = cell.target - cell.position
+    val dir = if (diff.magnitude > 0) diff.normalize else Vector2(0f, -1f)
+    dir * WanderingBehavior.CircleDistance
+  }
+
+  def displacementOnCircle = {
+    Vector2(cos(wanderAngle).toFloat, sin(wanderAngle).toFloat) * WanderingBehavior.CircleRadius
+  }
+}
+object WanderingBehavior {
+  // how far away the circle in front of the cell should be
+  final val CircleDistance = 50f
+
+  // how wide the circle in front of the cell should be
+  final val CircleRadius = 10f
+
+  // how much (radians) the wandering angle can shift per second
+  final val AngleChange = Pi / 2f
+}
+
+/**
+ * Returns the original cell target on update (does nothing).
+ *
+ * Use this when an entity is not controlled by the server.
+ */
+class NoBehavior(cell: Cell) extends SteeringBehavior {
+  def update(deltaSeconds: Float) = cell.target
+}

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -63,5 +63,21 @@ class CellSpec extends FlatSpec with Matchers {
 
     cell.position should equal(new Vector2(42f, 42f))
   }
+
+  it should "update its behavior on update" in {
+    val cell = new Cell(1, new Vector2(0f, 0f))
+    cell.behavior = new SpyBehavior
+
+    cell.update(1f)
+
+    cell.behavior shouldBe 'updated
+  }
 }
 
+class SpyBehavior extends SteeringBehavior {
+  var updated = false
+  def update(deltaSeconds: Float) = {
+    updated = true
+    new Vector2(0f, 0f)
+  }
+}

--- a/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
@@ -44,11 +44,11 @@ class SteeringBehaviorSpec extends FlatSpec with Matchers {
   }
 
   it should "return a circle center ahead of the cell" in {
-    val cell = new Cell(1, Vector2(0f, 0f))
-    cell.target = Vector2(5f, 0f)
+    val cell = new Cell(1, Vector2(5f, 5f))
+    cell.target = Vector2(10f, 5f)
     val behavior = new WanderingBehavior(cell)
 
-    behavior.circleCenter should equal(Vector2(WanderingBehavior.CircleDistance, 0f))
+    behavior.circleCenter should equal(Vector2(5f + WanderingBehavior.CircleDistance, 5f))
   }
 
   it should "return a displacement along the circle based on wander angle" in {

--- a/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
@@ -1,0 +1,46 @@
+import io.aigar.game._
+import org.scalatest._
+import com.github.jpbetz.subspace._
+
+class SteeringBehaviorSpec extends FlatSpec with Matchers {
+  "NoBehavior" should "return the same instance as the cell's target" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    cell.target = Vector2(10f, 10f)
+    val behavior = new NoBehavior(cell)
+
+    val target = behavior.update(1f)
+
+    target should be theSameInstanceAs(cell.target)
+  }
+
+  "WanderingBehavior" should "return a different target from the original one" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    cell.target = Vector2(10f, 10f)
+    val behavior = new WanderingBehavior(cell)
+
+    val target = behavior.update(1f)
+
+    target should not be theSameInstanceAs(cell.target)
+  }
+
+  it should "successively return different targets (wandering around)" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    cell.target = Vector2(10f, 10f)
+    val behavior = new WanderingBehavior(cell)
+    
+    val before = behavior.update(1f)
+    val after = behavior.update(1f)
+
+    val distance = before.distanceTo(after)
+
+    // Slight possibility that we get a random angle change of 0 (no change)
+    // We accept this rare event here.
+    distance should be > 0f
+
+    // Specific to wandering behavior: target should be within the circle ahead
+    // of our cell
+    distance should be <= 2 * WanderingBehavior.CircleRadius
+  }
+}
+
+

--- a/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
@@ -51,7 +51,7 @@ class SteeringBehaviorSpec extends FlatSpec with Matchers {
     behavior.circleCenter should equal(Vector2(5f + WanderingBehavior.CircleDistance, 5f))
   }
 
-  it should "return a displacement along the circle based on wander angle" in {
+  it should "return a displacement along the circle based on its wander angle" in {
     val cell = new Cell(1, Vector2(0f, 0f))
     val behavior = new WanderingBehavior(cell)
     behavior.wanderAngle = Pi.toFloat

--- a/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
@@ -1,4 +1,5 @@
 import io.aigar.game._
+import scala.math._
 import org.scalatest._
 import com.github.jpbetz.subspace._
 
@@ -40,6 +41,25 @@ class SteeringBehaviorSpec extends FlatSpec with Matchers {
     // Specific to wandering behavior: target should be within the circle ahead
     // of our cell
     distance should be <= 2 * WanderingBehavior.CircleRadius
+  }
+
+  it should "return a circle center ahead of the cell" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    cell.target = Vector2(5f, 0f)
+    val behavior = new WanderingBehavior(cell)
+
+    behavior.circleCenter should equal(Vector2(WanderingBehavior.CircleDistance, 0f))
+  }
+
+  it should "return a displacement along the circle based on wander angle" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    val behavior = new WanderingBehavior(cell)
+    behavior.wanderAngle = Pi.toFloat
+
+    val displacement = behavior.displacementOnCircle
+
+    displacement.x should equal(-WanderingBehavior.CircleRadius +- 1e-5f)
+    displacement.y should equal(0f +- 1e-5f)
   }
 }
 


### PR DESCRIPTION
Closes #107 .

Implements [wandering steering behaviour](https://gamedevelopment.tutsplus.com/tutorials/understanding-steering-behaviors-wander--gamedev-1624) (see visual example there). We will need to tweak this and make sure that it looks good soon, but I guess you could see this PR as a first draft of how we could handle the server AI.

Right now, `WanderingBehavior` is not used in the real game (only tested). My plan would be to jump on #121 as soon as this goes in. I think a really clean way to handle it would be to add a `onPlayerAction` on `SteeringBehavior` so that `WanderingBehavior` automatically switches to `NoBehavior` when the player is back online, and that `NoBehavior` automatically switches to `WanderingBehavior` if it the player was inactive for too long (`onPlayerAction` not called in a while)!