### PR TITLE
WanderingBehavior change target after some time

### DIFF
--- a/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
+++ b/game/src/main/scala/io/aigar/game/SteeringBehaviors.scala
@@ -20,11 +20,16 @@ trait SteeringBehavior {
 class WanderingBehavior(cell: Cell) extends SteeringBehavior {
   def isActive = false
 
+  var nextTargetTimeLeft = WanderingBehavior.NewTargetDelay
+
   /**
    * Picks a random target. Picks a new one once the previous one is reached.
    */
   def update(deltaSeconds: Float, grid: Grid) = {
-    if (cell.position.distanceTo(cell.target) <= WanderingBehavior.NewTargetDistance) {
+    nextTargetTimeLeft -= deltaSeconds
+
+    if (cell.contains(cell.target) || nextTargetTimeLeft <= 0f) {
+      nextTargetTimeLeft = WanderingBehavior.NewTargetDelay
       grid.randomPosition
     } else {
       cell.target
@@ -36,8 +41,8 @@ class WanderingBehavior(cell: Cell) extends SteeringBehavior {
   }
 }
 object WanderingBehavior {
-  // how close we have to be to our target to pick a new one
-  final val NewTargetDistance = 10f
+  // how long we have to wait to pick a new target (seconds)
+  final val NewTargetDelay = 10f
 }
 
 /**

--- a/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/SteeringBehaviorsSpec.scala
@@ -47,13 +47,25 @@ class SteeringBehaviorSpec extends FlatSpec with Matchers {
     target should be theSameInstanceAs(cell.target)
   }
 
-  it should "change target when close enough to the current target" in {
+  it should "change target when it reaches its target" in {
     val cell = new Cell(1, Vector2(10f, 10f))
     cell.target = Vector2(10f, 10f)
     cell.behavior = new WanderingBehavior(cell)
-    
+
     val target = cell.behavior.update(1f, new Grid(0, 0))
 
+    target should not be theSameInstanceAs(cell.target)
+  }
+
+  it should "change target after a certain delay" in {
+    val cell = new Cell(1, Vector2(0f, 0f))
+    val targetFar = Vector2(100000f, 100000f)
+    cell.target = targetFar
+    cell.behavior = new WanderingBehavior(cell)
+
+    val target = cell.behavior.update(WanderingBehavior.NewTargetDelay + 1e-2f, new Grid(0, 0))
+
+    cell.position.distanceTo(targetFar) should be > 100f // make sure that we really changed because of time (not position)
     target should not be theSameInstanceAs(cell.target)
   }
 


### PR DESCRIPTION
Closes #162 .

Added as a safety when the velocity of a cell prevents it from reaching its target (orbital effect).

I initially started by tweaking the distance parameter, but still managed to get some cases when a cell would orbit around its target. I figured tweaking a param was risky (especially if we want to run for a long time) and that we should just switch target after N seconds as a fallback (the AI is supposed to be dumb anyway).

We *could* look into implementing [arrival steering behavior](https://gamedevelopment.tutsplus.com/tutorials/understanding-steering-behaviors-flee-and-arrival--gamedev-1303) instead, but I think that's riskier and would look odd (why would a cell stop to reach an arbitrary target?)