### PR TITLE
[CHANGE BASE BEFORE MERGE] Mass represents cell's area

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -14,7 +14,7 @@ object Cell {
   /**
    * Default mass of a cell (at spawn).
    */
-  final val MinMass = 10f
+  final val MinMass = 20f
 
   /**
    * Ratio of mass lost per second.
@@ -67,7 +67,7 @@ class Cell(id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
   }
 
   def contains(pos: Vector2): Boolean = {
-    return position.distanceTo(pos) <= sqrt(mass / Pi)
+    return position.distanceTo(pos) <= sqrt(mass * Pi)
   }
 
   def eats(opponents: List[Player]): Unit ={

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -67,7 +67,7 @@ class Cell(id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
   }
 
   def contains(pos: Vector2): Boolean = {
-    return position.distanceTo(pos) <= mass
+    return position.distanceTo(pos) <= sqrt(mass / Pi)
   }
 
   def eats(opponents: List[Player]): Unit ={

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -43,8 +43,8 @@ class CellSpec extends FlatSpec with Matchers {
     val big = new Cell(2)
     big.target = new Vector2(100f, 100f)
 
-    small.mass = 1
-    big.mass = 1000
+    small.mass = Cell.MinMass
+    big.mass = 100 * Cell.MinMass
 
     small.acceleration.magnitude should be > big.acceleration.magnitude
   }
@@ -68,7 +68,7 @@ class CellSpec extends FlatSpec with Matchers {
   }
   it should "Not be in the cell" in {
     val cell = new Cell(1)
-    cell.mass = 3
+    cell.mass = Cell.MinMass
 
     val vec = new Vector2(42f, 42f)
     cell.contains(vec) should equal(false)
@@ -84,7 +84,7 @@ class CellSpec extends FlatSpec with Matchers {
   }
 
   it should "enforce a minimum mass" in {
-    var cell = new Cell(1, new Vector2(0f, 0f))
+    val cell = new Cell(1, new Vector2(0f, 0f))
 
     cell.mass = 0f
 
@@ -125,7 +125,7 @@ class CellSpec extends FlatSpec with Matchers {
 
   it should "not go below 0 x" in {
     val cell = new Cell(1, new Vector2(-5, 5))
-    val grid = new Grid(10, 10);
+    val grid = new Grid(10, 10)
 
     cell.update(1f, grid)
 
@@ -202,8 +202,8 @@ class CellSpec extends FlatSpec with Matchers {
     val smallCell = new Cell(2, new Vector2(10, 10))
     val opponent = new Player(2, Vector2(10, 10))
 
-    largeCell.mass = 21
-    smallCell.mass = 20
+    largeCell.mass = Cell.MinMass + 1
+    smallCell.mass = Cell.MinMass
     opponent.cells = List(smallCell)
 
     smallCell.eats(List(opponent))
@@ -216,8 +216,8 @@ class CellSpec extends FlatSpec with Matchers {
     val smallCell = new Cell(2, new Vector2(10, 10))
     val opponent = new Player(2, Vector2(10, 10))
 
-    largeCell.mass = 21
-    smallCell.mass = 20
+    largeCell.mass = Cell.MinMass + 1
+    smallCell.mass = Cell.MinMass
     opponent.cells = List(largeCell)
 
     smallCell.eats(List(opponent))

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -1,6 +1,7 @@
 import io.aigar.game._
 import org.scalatest._
 import com.github.jpbetz.subspace._
+import scala.math._
 
 class CellSpec extends FlatSpec with Matchers {
   "A Cell" should "not initiate movement when its target is on itself" in {
@@ -60,7 +61,7 @@ class CellSpec extends FlatSpec with Matchers {
 
   it should "Be in the cell" in {
     val cell = new Cell(1)
-    cell.mass = 100
+    cell.mass = (pow(100f, 2) / Pi).toFloat
 
     val vec = new Vector2(42f, 42f)
     cell.contains(vec) should equal(true)

--- a/game/src/test/scala/io/aigar/game/PlayerSpec.scala
+++ b/game/src/test/scala/io/aigar/game/PlayerSpec.scala
@@ -28,12 +28,12 @@ class PlayerSpec extends FlatSpec with Matchers {
   it should "generate a state with the right info" in {
     val player = new Player(1, new Vector2(0f, 0f))
     player.cells = List(new Cell(1), new Cell(2))
-    player.cells(0).mass = 10
+    player.cells(0).mass = Cell.MinMass
     player.cells(1).mass = 25
 
     val state = player.state
 
-    state.total_mass should equal(35)
+    state.total_mass should equal(25 + Cell.MinMass)
     state.id should equal(1)
     state.cells should have size 2
   }

--- a/web/src/javascript/drawMap.js
+++ b/web/src/javascript/drawMap.js
@@ -57,7 +57,7 @@ export function drawPlayersOnMap(players, canvas) {
   for(const player of players) {
     const color = getPlayerColor(players, player);
     for(const cell of player.cells) {
-      drawCircle(context, cell.position, cell.mass, color);
+      drawCircle(context, cell.position, Math.sqrt(cell.mass * Math.PI), color);
     }
   }
 }
@@ -69,7 +69,7 @@ export function drawFoodOnMap(foods, canvas) {
       var grd=context.createRadialGradient(food.x,food.y, .5, food.x, food.y,constants.foodMass);
       grd.addColorStop(0,color);
       grd.addColorStop(1, rgba);
-      drawCircle(context, food, sqrt(mass / Math.PI), grd);
+      drawCircle(context, food, mass, grd);
     }
   };
   

--- a/web/src/javascript/drawMap.js
+++ b/web/src/javascript/drawMap.js
@@ -69,7 +69,7 @@ export function drawFoodOnMap(foods, canvas) {
       var grd=context.createRadialGradient(food.x,food.y, .5, food.x, food.y,constants.foodMass);
       grd.addColorStop(0,color);
       grd.addColorStop(1, rgba);
-      drawCircle(context, food, mass, grd);
+      drawCircle(context, food, sqrt(mass / Math.PI), grd);
     }
   };
   


### PR DESCRIPTION
I first start with radius equals to `sqrt(Mass/PI)` but it was way to small. 

Tweeked it by putting the `Cell.MinMass` to 20.

Was not enough, so ended putting the radius to `sqrt(Mass * PI)` instead. Looks nice.

I also tweeked some tests for Cell and Player where there was mass with a lower value than the `Cell.MinMass` to make sure they don't fail.

Closes #98 