### PR TITLE
Always update cell

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -2,9 +2,9 @@ package io.aigar.game
 
 import io.aigar.controller.response.Action
 import scala.math.{max, round, pow}
-import io.aigar.game.Vector2Utils._
-import io.aigar.game.Position2Utils._
-import com.github.jpbetz.subspace._
+import io.aigar.game.Vector2Utils.StateAddon
+import io.aigar.game.Position2Utils.PositionAddon
+import com.github.jpbetz.subspace.Vector2
 import scala.math._
 
 object Cell {
@@ -27,7 +27,7 @@ object Cell {
 class Cell(val id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
   var position = startPosition
   var target = startPosition
-  var behavior: SteeringBehavior = new NoBehavior(this)
+  var behavior: SteeringBehavior = new WanderingBehavior(this)
   var _mass = Cell.MinMass
   private var _velocity = new Vector2(0f, 0f)
 
@@ -35,16 +35,16 @@ class Cell(val id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
    * The maximum speed (length of the velocity) for the cell, in units per
    * second.
    */
-  def maxSpeed = {
+  def maxSpeed: Float = {
     50f //TODO depend on mass?
   }
 
-  def velocity = _velocity
-  def velocity_=(vel:Vector2) {
+  def velocity: Vector2 = _velocity
+  def velocity_=(vel:Vector2): Unit = {
     _velocity = if (vel.magnitude < maxSpeed) vel else vel.normalize * maxSpeed
   }
-  def mass = _mass
-  def mass_=(m: Float) {
+  def mass: Float = _mass
+  def mass_=(m: Float): Unit = {
     _mass = max(m, Cell.MinMass)
   }
 
@@ -62,18 +62,18 @@ class Cell(val id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
     position = position.clamp(new Vector2(0f, 0f), new Vector2(grid.width, grid.height))
   }
 
-  def decayedMass(deltaSeconds: Float) = {
+  def decayedMass(deltaSeconds: Float): Float = {
     mass * pow(1f - Cell.MassDecayPerSecond, deltaSeconds).toFloat
   }
 
   def acceleration: Vector2 = {
     val dir = target - position
     val value = Cell.MovementForce / mass
-    return if (dir.magnitude > 0) dir.normalize * value else new Vector2(0f,0f)
+    if (dir.magnitude > 0) dir.normalize * value else new Vector2(0f,0f)
   }
 
   def contains(pos: Vector2): Boolean = {
-    return position.distanceTo(pos) <= radius
+    position.distanceTo(pos) <= radius
   }
 
   def eats(opponents: List[Player]): Unit ={
@@ -91,7 +91,7 @@ class Cell(val id: Int, startPosition: Vector2 = new Vector2(0f, 0f)) {
     target = action.target.toVector
   }
 
-  def state = {
+  def state: serializable.Cell = {
     serializable.Cell(id,
                       round(radius).toInt,
                       position.state,

--- a/game/src/main/scala/io/aigar/game/Player.scala
+++ b/game/src/main/scala/io/aigar/game/Player.scala
@@ -2,7 +2,7 @@ package io.aigar.game
 
 import io.aigar.controller.response.Action
 import scala.math.round
-import com.github.jpbetz.subspace._
+import com.github.jpbetz.subspace.Vector2
 
 class Player(val id: Int, startPosition: Vector2) {
   var cells = List(new Cell(0, startPosition))
@@ -11,14 +11,12 @@ class Player(val id: Int, startPosition: Vector2) {
     if ( cells.isEmpty ) {
       cells = List(new Cell(0, grid.randomPosition))
     }
-    else {
-      val opponents = players.filterNot(_ == this)
-      cells.foreach { _.update(deltaSeconds, grid) }
-      cells.foreach { _.eats(opponents) }
-    }
+    val opponents = players.filterNot(_ == this)
+    cells.foreach { _.update(deltaSeconds, grid) }
+    cells.foreach { _.eats(opponents) }
   }
 
-  def state = {
+  def state: serializable.Player = {
     val mass = round(cells.map(_.mass).sum).toInt
     serializable.Player(id,
                         id.toString,
@@ -43,7 +41,7 @@ class Player(val id: Int, startPosition: Vector2) {
    * Should be called whenever an external action occurs (e.g. we receive a
    * command coming from the AI of a player).
    */
-  def onExternalAction = {
+  def onExternalAction: Unit = {
     cells.foreach { _.behavior.onPlayerActivity }
   }
 

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -10,6 +10,7 @@ class CellSpec extends FlatSpec with Matchers {
   "A Cell" should "not initiate movement when its target is on itself" in {
     val cell = new Cell(1, new Vector2(42f, 42f))
     cell.target = new Vector2(42f, 42f)
+    cell.behavior = new NoBehavior(cell)
     val grid = new Grid(100, 100);
 
     cell.update(1f, grid)
@@ -79,6 +80,7 @@ class CellSpec extends FlatSpec with Matchers {
 
   it should "not move without setting its target" in {
     val cell = new Cell(1, new Vector2(42f, 42f))
+    cell.behavior = new NoBehavior(cell)
     val grid = new Grid(200, 200)
 
     cell.update(1f, grid)


### PR DESCRIPTION
Closes #212.

Did some refactoring.

This is doing 2 things (I know, sorry).
- The `update` on cells is still called when we create a new cell.
- The default behavior for cell is now `WanderingBehavior` rather than `NoBehavior`. The reason is that `NoBehavior` has two meanings, controlled by a player AND that a player used recently. The effect of the second thing was that the player was showing active after a respawn, which I think was not acceptable. What do you think?
