### PR TITLE
Python Player class and display refactor

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -22,7 +22,7 @@ Attributes:
 
 - `tick`: How many updates the game has gone through so far
 
-- `players`: List of players in the game
+- `players`: List of players (`Player` objects) in the game
 
 - `resources`: Resources in the game that can be collected to gain mass/points
 
@@ -37,3 +37,21 @@ Attributes:
 - `width`: Width of the map
 
 - `height`: Height of the map
+
+### Player
+Owner and controller of cells in the game. As a programmer of an AI, you are a
+`Player`.
+
+Attributes:
+- `id`: Identifier of the player
+
+- `name`: Display name of the player in-game
+
+- `cells`: List of `Cell` objects that the player owns and controls
+
+- `total_mass`: Sum of the mass of the player's cells
+
+- `active`: Whether the player is actively controlling their cells or not. If a
+            player's AI is inactive for too long, this flag will become `False`
+            and a dumb AI will take over the player's cells until the player
+            becomes active once again.

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -19,6 +19,15 @@ class Game:
                 []     # TODO Virus.parse
                 )
 
+    def __str__(self):
+        return ("""
+Tick: %d
+Map: %s
+Players:
+  %s""" % (self.tick,
+           self.map,
+           "\n  ".join([str(player) for player in self.players])))
+
 
 class Map:
     def __init__(self, width, height):
@@ -27,6 +36,9 @@ class Map:
 
     def parse(obj):
         return Map(obj["width"], obj["height"])
+
+    def __str__(self):
+        return "%d x %d" % (self.width, self.height)
 
 
 class Player:
@@ -45,3 +57,10 @@ class Player:
                 obj["isActive"],
                 []  # TODO Cell.parse
                 )
+
+    def __str__(self):
+        return ("%d '%s' %s mass=%d cells=[%s]" %
+                (self.id, self.name,
+                 "active" if self.active else "inactive",
+                 self.total_mass,
+                 ", ".join([str(cell) for cell in self.cells])))

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -13,7 +13,7 @@ class Game:
         return Game(
                 obj["id"],
                 obj["tick"],
-                [],    # TODO Player.parse
+                [Player.parse(player) for player in obj["players"]],
                 [],    # TODO Resources.parse
                 Map.parse(obj["map"]),
                 []     # TODO Virus.parse

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -27,3 +27,21 @@ class Map:
 
     def parse(obj):
         return Map(obj["width"], obj["height"])
+
+
+class Player:
+    def __init__(self, id_, name, total_mass, active, cells):
+        self.id = id_
+        self.name = name
+        self.total_mass = total_mass
+        self.active = active
+        self.cells = cells
+
+    def parse(obj):
+        return Player(
+                obj["id"],
+                obj["name"],
+                obj["total_mass"],
+                obj["isActive"],
+                []  # TODO Cell.parse
+                )

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -11,7 +11,16 @@ class GameTests(TestCase):
                 "map": {
                     "width": 111,
                     "height": 222
-                    }
+                    },
+                "players": [
+                    {
+                        "id": "a",
+                        "name": "b",
+                        "total_mass": 23,
+                        "isActive": True,
+                        "cells": []  # TODO once Cells are implemented
+                        }
+                    ]
                 # TODO add more here
                 }
 
@@ -19,8 +28,17 @@ class GameTests(TestCase):
 
         self.assertEqual(12, game.id)
         self.assertEqual(123, game.tick)
+
         self.assertEqual(111, game.map.width)
         self.assertEqual(222, game.map.height)
+
+        self.assertEqual(1, len(game.players))
+        player = game.players[0]
+        self.assertEqual("a", player.id)
+        self.assertEqual("b", player.name)
+        self.assertEqual(23, player.total_mass)
+        self.assertEqual(True, player.active)
+
         # TODO add more here
 
 

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from .models import Game, Map
+from .models import Game, Player, Map
 
 
 class GameTests(TestCase):
@@ -35,3 +35,22 @@ class MapTests(TestCase):
 
         self.assertEqual(123, map_.width)
         self.assertEqual(321, map_.height)
+
+
+class PlayerTests(TestCase):
+    def test_parse(self):
+        obj = {
+                "id": "bob",
+                "name": "alice",
+                "total_mass": 42,
+                "isActive": True,
+                "cells": {}  # TODO once Cells are implemented
+                }
+
+        player = Player.parse(obj)
+
+        self.assertEqual("bob", player.id)
+        self.assertEqual("alice", player.name)
+        self.assertEqual(42, player.total_mass)
+        self.assertEqual(True, player.active)
+        # TODO test cell equality here

--- a/clients/python/play.py
+++ b/clients/python/play.py
@@ -19,9 +19,7 @@ def main():
         game = api.fetch_game_state(game_id)
 
         # TODO call player AI here
-        print("Tick: %d" % game.tick)
-        print("Map: %d by %d" % (game.map.width, game.map.height))
-        print()
+        print(str(game))
 
         sleep(1 / UpdatesPerSecond)
 


### PR DESCRIPTION
Did both of these things because it was convenient (sorry):
- `Player` class
- define `__str__` and use that for displaying purposes -- this might be useful for the participants when debugging!

Sample:
```python
Tick: 319846
Players:
  1 'player1' inactive mass=20 cells=[]
  2 'player2' inactive mass=20 cells=[]
  3 'player3' inactive mass=20 cells=[]
  4 'player4' inactive mass=102 cells=[]
  5 'player5' inactive mass=22 cells=[]
  6 'player6' inactive mass=20 cells=[]
  7 'player7' inactive mass=21 cells=[]
  8 'player8' inactive mass=20 cells=[]
  9 'player9' inactive mass=21 cells=[]
  10 'player10' inactive mass=20 cells=[]
  11 'player11' inactive mass=48 cells=[]
  12 'player12' inactive mass=25 cells=[]
  13 'player13' inactive mass=24 cells=[]
  14 'player14' inactive mass=24 cells=[]
  15 'player15' inactive mass=21 cells=[]
```