### PR TITLE
Add back mass of cell in API

### DIFF
--- a/API.md
+++ b/API.md
@@ -46,6 +46,7 @@ Every error will contain a root element named `error` with an error message.
         {
             "id": "int",
             "mass": "int",
+            "radius": "float",
             "position": {
                 "x": "float",
                 "y": "float"

--- a/API.md
+++ b/API.md
@@ -46,7 +46,7 @@ Every error will contain a root element named `error` with an error message.
         {
             "id": "int",
             "mass": "int",
-            "radius": "float",
+            "radius": "int",
             "position": {
                 "x": "float",
                 "y": "float"

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -104,6 +104,7 @@ class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f,
 
   def state: serializable.Cell = {
     serializable.Cell(id,
+                      round(mass).toInt,
                       round(radius).toInt,
                       position.state,
                       target.state)

--- a/game/src/main/scala/io/aigar/game/serializable/GameState.scala
+++ b/game/src/main/scala/io/aigar/game/serializable/GameState.scala
@@ -18,6 +18,7 @@ case class Dimensions(
 )
 case class Cell(
   id: Int,
+  mass: Int,
   radius: Int,
   position: Position,
   target: Position

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -66,7 +66,8 @@ class CellSpec extends FlatSpec with Matchers {
     val state = cell.state
 
     state.id should equal(0)
-    state.radius should equal(round(sqrt(cell.mass * Pi)))
+    state.mass should equal(100)
+    state.radius should equal(cell.radius)
   }
 
   it should "Be in the cell" in {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -67,7 +67,7 @@ class CellSpec extends FlatSpec with Matchers {
 
     state.id should equal(0)
     state.mass should equal(100)
-    state.radius should equal(cell.radius)
+    state.radius should equal(round(cell.radius).toInt)
   }
 
   it should "Be in the cell" in {


### PR DESCRIPTION
Closes #234 .

Can be useful for AIs.

Minor:
- added `radius` to API docs
- simplified one of the tests (used `cell.radius`)