### PR TITLE
Add python Cell class

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -56,10 +56,39 @@ Owner and controller of cells in the game. As a programmer of an AI, you are a
             and a dumb AI will take over the player's cells until the player
             becomes active once again.
 
+### Cell
+Individual entity controlled by a `Player`. Through movement, it can consume
+resources and enemy cells to grow. It loses a portion of its mass over time.
+
+A cell can be moved by changing its `target`.
+
+To collect a resource, a cell must collide with it.
+
+To eat an enemy cell, a cell must almost completely overlap its enemy and be
+10% bigger than it.
+
+#### Attributes
+- `id`: Identifier of the cell
+
+- `mass`: Mass of the cell.
+          The bigger the mass, the bigger the cell, the slower the cell can move
+          or accelerate.
+          Mass decays over time (by a ratio of the current mass).
+
+- `radius`: Radius of the cell, influenced by its current mass
+
+- `position`: Current position (`Vec2` object) of the cell in the `Map`
+
+- `target`: Target (`Vec2` object) that the cell should go for.
+            Move the cell by changing this value.
+
+
 ### Resources
 Contains the information about the resources available on the map. Collecting
 those resources with a cell results in a potential increase of a cell's mass
 and a player's overall score in the competition.
+
+To collect a resource, a `Cell` must collide with it.
 
 There are three available resource types:
 | Resource Type | Cell Mass Gain | Player Score Gain |

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -74,6 +74,29 @@ class Player:
                  ", ".join([str(cell) for cell in self.cells])))
 
 
+class Cell:
+    def __init__(self, id_, mass, radius, position, target):
+        self.id = id_
+        self.mass = mass
+        self.radius = radius
+        self.position = position
+        self.target = target
+
+    def parse(obj):
+        return Cell(
+                obj["id"],
+                obj["mass"],
+                obj["radius"],
+                parse_vec2(obj["position"]),
+                parse_vec2(obj["target"])
+                )
+
+    def __str__(self):
+        return ("#%d (%d) %s -> %s" %
+                self.id, self.mass,
+                format_vec2(self.position), format_vec2(self.target))
+
+
 class Resources:
     def __init__(self, regular_positions, silver_positions, gold_positions):
         self.regular = regular_positions

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -93,8 +93,8 @@ class Cell:
 
     def __str__(self):
         return ("#%d (%d) %s -> %s" %
-                self.id, self.mass,
-                format_vec2(self.position), format_vec2(self.target))
+                (self.id, self.mass,
+                 format_vec2(self.position), format_vec2(self.target)))
 
 
 class Resources:

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -63,7 +63,7 @@ class Player:
                 obj["name"],
                 obj["total_mass"],
                 obj["isActive"],
-                []  # TODO Cell.parse
+                [Cell.parse(cell) for cell in obj["cells"]]
                 )
 
     def __str__(self):

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from planar import Vec2
 
-from .models import Game, Map, Player, Resources, Virus
+from .models import Game, Map, Player, Cell, Resources, Virus
 
 
 class GameTests(TestCase):
@@ -91,6 +91,25 @@ class PlayerTests(TestCase):
         self.assertEqual(42, player.total_mass)
         self.assertEqual(True, player.active)
         # TODO test cell equality here
+
+
+class CellTests(TestCase):
+    def test_parse(self):
+        obj = {
+                "id": 1,
+                "mass": 12,
+                "radius": 8,
+                "position": {"x": 1241, "y": 442},
+                "target": {"x": 1448, "y": 1136}
+                }
+
+        cell = Cell.parse(obj)
+
+        self.assertEqual(1, cell.id)
+        self.assertEqual(12, cell.mass)
+        self.assertEqual(8, cell.radius)
+        self.assertTrue(cell.position.almost_equals(Vec2(1241, 442)))
+        self.assertTrue(cell.target.almost_equals(Vec2(1448, 1136)))
 
 
 class ResourcesTests(TestCase):

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -19,7 +19,13 @@ class GameTests(TestCase):
                         "name": "b",
                         "total_mass": 23,
                         "isActive": True,
-                        "cells": []  # TODO once Cells are implemented
+                        "cells": [{
+                            "id": 1,
+                            "mass": 2,
+                            "radius": 3,
+                            "position": {"x": 1, "y": 2},
+                            "target": {"x": 3, "y": 4}
+                            }]
                         }
                     ],
                 "resources": {
@@ -47,6 +53,14 @@ class GameTests(TestCase):
         self.assertEqual("b", player.name)
         self.assertEqual(23, player.total_mass)
         self.assertEqual(True, player.active)
+
+        self.assertEqual(1, len(player.cells))
+        cell = player.cells[0]
+        self.assertEqual(1, cell.id)
+        self.assertEqual(2, cell.mass)
+        self.assertEqual(3, cell.radius)
+        self.assertTrue(cell.position.almost_equals(Vec2(1, 2)))
+        self.assertTrue(cell.target.almost_equals(Vec2(3, 4)))
 
         self.assertEqual(1, len(game.resources.regular))
         self.assertTrue(game.resources.regular[0].almost_equals(Vec2(1, 2)))
@@ -81,7 +95,13 @@ class PlayerTests(TestCase):
                 "name": "alice",
                 "total_mass": 42,
                 "isActive": True,
-                "cells": {}  # TODO once Cells are implemented
+                "cells": [{
+                    "id": 1,
+                    "mass": 2,
+                    "radius": 3,
+                    "position": {"x": 1, "y": 2},
+                    "target": {"x": 3, "y": 4}
+                    }]
                 }
 
         player = Player.parse(obj)
@@ -90,7 +110,14 @@ class PlayerTests(TestCase):
         self.assertEqual("alice", player.name)
         self.assertEqual(42, player.total_mass)
         self.assertEqual(True, player.active)
-        # TODO test cell equality here
+
+        self.assertEqual(1, len(player.cells))
+        cell = player.cells[0]
+        self.assertEqual(1, cell.id)
+        self.assertEqual(2, cell.mass)
+        self.assertEqual(3, cell.radius)
+        self.assertTrue(cell.position.almost_equals(Vec2(1, 2)))
+        self.assertTrue(cell.target.almost_equals(Vec2(3, 4)))
 
 
 class CellTests(TestCase):

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -22,6 +22,13 @@ object Cell {
    * Ratio of mass lost per second.
    */
   final val MassDecayPerSecond = 0.005f
+
+  /**
+   * How much bigger a cell must be to eat an enemy cell (ratio).
+   *
+   * IMPORTANT keep this value in sync with the client documentation
+   */
+  final val MassDominanceRatio = 1.1f
 }
 
 class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f, 0f)) {
@@ -90,7 +97,7 @@ class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f,
   def eats(opponents: List[Player]): Unit ={
     for(opponent <- opponents) {
       for(cell <- opponent.cells) {
-        if (contains(cell.position) && mass >= 1.1 * cell.mass) { //Cell must be 10% larger to eat it
+        if (contains(cell.position) && mass >= Cell.MassDominanceRatio * cell.mass) {
           mass = mass + cell.mass
           opponent.removeCell(cell)
         }


### PR DESCRIPTION
I tried to make a bit of a richer documentation for this one -- what a cell can do, etc.

I added a constant in `Cell.scala` to make sure that we don't forget to update the documentation.

Sample output (bad masses because #259 is not there yet, temporary values):
```
Tick: 84656
Map: 1500 x 1500
Players:
  1 'player1' inactive mass=20 cells=[#7 (8) (960,688) -> (1154,1242)]
  2 'player2' inactive mass=20 cells=[#1 (8) (805,680) -> (1409,1333)]
  3 'player3' inactive mass=20 cells=[#7 (8) (801,494) -> (136,481)]
  4 'player4' inactive mass=23 cells=[#4 (9) (976,332) -> (409,572)]
  5 'player5' inactive mass=20 cells=[#7 (8) (1028,1258) -> (179,203)]
  6 'player6' inactive mass=20 cells=[#7 (8) (905,879) -> (965,838)]
  7 'player7' inactive mass=20 cells=[#2 (8) (987,489) -> (1408,193)]
  8 'player8' inactive mass=84 cells=[#5 (16) (953,608) -> (1134,1474)]
  9 'player9' inactive mass=20 cells=[#1 (8) (1290,1019) -> (1388,1468)]
  10 'player10' inactive mass=20 cells=[#10 (8) (1019,192) -> (1008,137)]
  11 'player11' inactive mass=21 cells=[#5 (8) (855,357) -> (115,1083)]
  12 'player12' inactive mass=20 cells=[#1 (8) (664,113) -> (1286,1198)]
  13 'player13' inactive mass=20 cells=[#4 (8) (1092,828) -> (629,247)]
  14 'player14' inactive mass=20 cells=[#7 (8) (1175,895) -> (1008,521)]
  15 'player15' inactive mass=32 cells=[#0 (10) (829,1063) -> (935,202)]
Resources:
  regular: 250, silver: 25, gold: 10
```