### PR TITLE
Virus backend without cell split physic

### DIFF
--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -20,6 +20,7 @@ class Game(val id: Int, playerIDs: List[Int]) {
 
   def update(deltaSeconds: Float): List[ScoreModification] = {
     players.foreach { player => player.update(deltaSeconds, grid, players) }
+    viruses.foreach { virus => virus.update(grid, players) }
     val scoreModifications = resources.update(players)
     tick += 1
 

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -14,6 +14,7 @@ object Game {
 class Game(val id: Int, playerIDs: List[Int]) {
   val grid = new Grid(playerIDs.length * Grid.WidthPerPlayer, playerIDs.length * Grid.HeightPerPlayer)
   val players = createPlayers
+  val viruses = createViruses
   val resources = new Resources(grid)
   var tick = 0
 
@@ -37,15 +38,19 @@ class Game(val id: Int, playerIDs: List[Int]) {
     serializable.GameState(
         id,
         tick,
-        players.map(_.state).toList,
+        players.map(_.state),
         resources.state,
         grid.state,
-        List[serializable.Position]()
+        viruses.map(_.state)
       )
   }
 
   def createPlayers = {
     playerIDs.map { new Player(_, spawnPosition) }
+  }
+
+  def createViruses: List[Virus] = {
+    List.fill(Virus.Quantity)(new Virus(grid.randomPosition))
   }
 
   def spawnPosition = {

--- a/game/src/main/scala/io/aigar/game/Resources.scala
+++ b/game/src/main/scala/io/aigar/game/Resources.scala
@@ -37,8 +37,7 @@ class Resources(grid: Grid) {
   var resourceTypes = List(regular, silver, gold)
 
   def update(players: List[Player]): List[ScoreModification] = {
-    val scoreModifications = resourceTypes.map(_.detectCollisions(players))
-      .flatten
+    val scoreModifications = resourceTypes.flatten(_.detectCollisions(players))
     resourceTypes.foreach(_.spawnResources(players))
 
     scoreModifications
@@ -60,7 +59,7 @@ class ResourceType(grid: Grid, val min: Int, val max: Int, mass: Int, score: Int
     val ratio = (positions.length - min).toFloat / (max - min)
 
     if (scala.util.Random.nextFloat >= ratio) {
-      var position = grid.randomPosition
+      val position = grid.randomPosition
       for (player <- players) {
         for (cell <- player.cells) {
           if (cell.contains(position)) return

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -10,22 +10,24 @@ object Virus {
 
 class Virus(var position: Vector2) {
   def update(grid: Grid, players: List[Player]): Unit = {
-    if(detectCollisions(players)) {
+    val cell = detectCollisions(players)
+     cell match {
       // TODO Add the virus consumption into the cell
-      respawn(grid, players)
+      case Some(c: Cell) => respawn(grid, players)
+      case _ =>
     }
   }
 
-  def detectCollisions(players: List[Player]): Boolean ={
+  def detectCollisions(players: List[Player]): Option[Cell] ={
     for(player <- players) {
       for(cell <- player.cells) {
         // TODO Change the 1.1 value to the constant
         if(cell.contains(position) && cell.mass > Virus.Mass * 1.1){
-          return true
+          return Some(cell)
         }
       }
     }
-    false
+    None
   }
 
   def respawn(grid: Grid, players: List[Player]): Unit = {

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -7,6 +7,7 @@ import io.aigar.game.Vector2Utils.StateAddon
 object Virus {
   final val Quantity = 15
   final val Mass = 100
+  final val RespawnRetryAttempts = 15
 }
 
 class Virus(var position: Vector2) {
@@ -23,7 +24,7 @@ class Virus(var position: Vector2) {
     for(player <- players) {
       for(cell <- player.cells) {
         // TODO Change the 1.1 value to the constant
-        if(cell.contains(position) && cell.mass > Virus.Mass * 1.1){
+        if(cell.contains(position) && cell.mass > Virus.Mass * Cell.MassDominanceRatio){
           return Some(cell)
         }
       }
@@ -34,7 +35,7 @@ class Virus(var position: Vector2) {
   def respawn(grid: Grid, players: List[Player]): Unit = {
     var newPosition = grid.randomPosition
 
-    1 to 15 foreach { _ =>
+    1 to Virus.RespawnRetryAttempts foreach { _ =>
       for (player <- players) {
         for (cell <- player.cells) {
           if (cell.contains(position))

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -9,7 +9,6 @@ object Virus {
 }
 
 class Virus(var position: Vector2) {
-
   def update(grid: Grid, players: List[Player]): Unit = {
     if(detectCollisions(players)) {
       // TODO Add the virus consumption into the cell
@@ -30,15 +29,14 @@ class Virus(var position: Vector2) {
   }
 
   def respawn(grid: Grid, players: List[Player]): Unit = {
-    val newPosition = grid.randomPosition
+    val listPositions = players.map { _.cells.map { _.position} }
+    var newPosition = grid.randomPosition
 
-    // We always want 15 viruses. How to we manage it without doing a while true loop?
-    for (player <- players) {
-      for (cell <- player.cells) {
-        if (cell.contains(newPosition)) return
+    1 to 15 foreach { _ =>
+      if (listPositions.contains(newPosition)) {
+        newPosition = grid.randomPosition
       }
     }
-
     position = newPosition
   }
 

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -8,7 +8,39 @@ object Virus {
   final val Mass = 100
 }
 
-class Virus(position: Vector2) {
+class Virus(var position: Vector2) {
+
+  def update(grid: Grid, players: List[Player]): Unit = {
+    if(detectCollisions(players)) {
+      // TODO Add the virus consumption into the cell
+      respawn(grid, players)
+    }
+  }
+
+  def detectCollisions(players: List[Player]): Boolean ={
+    for(player <- players) {
+      for(cell <- player.cells) {
+        // TODO Change the 1.1 value to the constant
+        if(cell.contains(position) && cell.mass > Virus.Mass * 1.1){
+          return true
+        }
+      }
+    }
+    false
+  }
+
+  def respawn(grid: Grid, players: List[Player]): Unit = {
+    val newPosition = grid.randomPosition
+
+    // We always want 15 viruses. How to we manage it without doing a while true loop?
+    for (player <- players) {
+      for (cell <- player.cells) {
+        if (cell.contains(newPosition)) return
+      }
+    }
+
+    position = newPosition
+  }
 
   def state: Position = {
     Vector2Utils.StateAddon(position).state

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -29,12 +29,14 @@ class Virus(var position: Vector2) {
   }
 
   def respawn(grid: Grid, players: List[Player]): Unit = {
-    val listPositions = players.map { _.cells.map { _.position} }
     var newPosition = grid.randomPosition
 
     1 to 15 foreach { _ =>
-      if (listPositions.contains(newPosition)) {
-        newPosition = grid.randomPosition
+      for (player <- players) {
+        for (cell <- player.cells) {
+          if (cell.contains(position))
+            newPosition = grid.randomPosition
+        }
       }
     }
     position = newPosition

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -2,6 +2,7 @@ package io.aigar.game
 
 import com.github.jpbetz.subspace.Vector2
 import io.aigar.game.serializable.Position
+import io.aigar.game.Vector2Utils.StateAddon
 
 object Virus {
   final val Quantity = 15
@@ -45,6 +46,6 @@ class Virus(var position: Vector2) {
   }
 
   def state: Position = {
-    Vector2Utils.StateAddon(position).state
+    position.state
   }
 }

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -1,0 +1,16 @@
+package io.aigar.game
+
+import com.github.jpbetz.subspace.Vector2
+import io.aigar.game.serializable.Position
+
+object Virus {
+  final val Quantity = 15
+  final val Mass = 100
+}
+
+class Virus(position: Vector2) {
+
+  def state: Position = {
+    Vector2Utils.StateAddon(position).state
+  }
+}

--- a/game/src/test/scala/io/aigar/game/GameSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameSpec.scala
@@ -27,6 +27,12 @@ class GameSpec extends FlatSpec with Matchers {
     game.players should have size 10
   }
 
+  it should "create just enough viruses" in {
+    val game = new Game(42, 1 to 10 toList)
+
+    game.viruses should have size Virus.Quantity
+  }
+
   it should "spawn players at distinct positions at creation" in {
     val game = new Game(42, 1 to 10 toList)
 

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -11,4 +11,26 @@ class VirusSpec extends FlatSpec with Matchers {
 
     virus.state should equal(new Position(5, 6))
   }
+
+  it should "not detect a collision when being into a smaller cell" in {
+    val virus = new Virus(new Vector2(5, 5))
+    val player = new Player(1, new Vector2(5, 5))
+    val cell = new Cell(1, player, new Vector2(5, 5))
+
+    cell.mass = 80
+    player.cells = List(cell)
+
+    virus.detectCollisions(List(player)) shouldBe false
+  }
+
+  it should "detect a collision when being into a larger cell" in {
+    val virus = new Virus(new Vector2(5, 5))
+    val player = new Player(1, new Vector2(5, 5))
+    val cell = new Cell(1, player, new Vector2(5, 5))
+
+    cell.mass = 120
+    player.cells = List(cell)
+
+    virus.detectCollisions(List(player)) shouldBe true
+  }
 }

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -1,0 +1,14 @@
+package io.aigar.game
+
+import com.github.jpbetz.subspace.Vector2
+import io.aigar.game.serializable.Position
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class VirusSpec extends FlatSpec with Matchers {
+  "A Virus" should "create a state with the right info" in {
+    val virus = new Virus(new Vector2(5, 6))
+
+    virus.state should equal(new Position(5, 6))
+  }
+}

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -33,4 +33,19 @@ class VirusSpec extends FlatSpec with Matchers {
 
     virus.detectCollisions(List(player)) shouldBe true
   }
+
+  it should "not respawn on a cell" in {
+    val grid = new Grid(1000, 1000)
+    val initialPosition = new Vector2(5, 5)
+    val virus = new Virus(initialPosition)
+    val player = new Player(1, initialPosition)
+    val cell = new Cell(1, player, initialPosition)
+
+    cell.mass = 200
+    player.cells = List(cell)
+
+    virus.respawn(grid, List(player))
+
+    virus.position should not be initialPosition
+  }
 }

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -17,10 +17,11 @@ class VirusSpec extends FlatSpec with Matchers {
     val player = new Player(1, new Vector2(5, 5))
     val cell = new Cell(1, player, new Vector2(5, 5))
 
-    cell.mass = 80
+    // We make sure the cell is small enough so it doesn't eat the virus
+    cell.mass = Virus.Mass / Cell.MassDominanceRatio - 1
     player.cells = List(cell)
 
-    virus.detectCollisions(List(player)) equals None
+    virus.detectCollisions(List(player))should equal(None)
   }
 
   it should "detect a collision when being into a larger cell" in {
@@ -28,10 +29,11 @@ class VirusSpec extends FlatSpec with Matchers {
     val player = new Player(1, new Vector2(5, 5))
     val cell = new Cell(1, player, new Vector2(5, 5))
 
-    cell.mass = 120
+    // We make sure the cell is big enough to eat the virus
+    cell.mass = Virus.Mass * Cell.MassDominanceRatio + 1
     player.cells = List(cell)
 
-    virus.detectCollisions(List(player)) equals Some(Cell)
+    virus.detectCollisions(List(player)) should equal(Some(cell))
   }
 
   it should "not respawn on a cell" in {

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -20,7 +20,7 @@ class VirusSpec extends FlatSpec with Matchers {
     cell.mass = 80
     player.cells = List(cell)
 
-    virus.detectCollisions(List(player)) shouldBe false
+    virus.detectCollisions(List(player)) equals None
   }
 
   it should "detect a collision when being into a larger cell" in {
@@ -31,7 +31,7 @@ class VirusSpec extends FlatSpec with Matchers {
     cell.mass = 120
     player.cells = List(cell)
 
-    virus.detectCollisions(List(player)) shouldBe true
+    virus.detectCollisions(List(player)) equals Some(Cell)
   }
 
   it should "not respawn on a cell" in {


### PR DESCRIPTION
I'm currently initializing the viruses, make them update, detectCollision and respawn but I have few issues.

1. Jesse made me a suggestion that I would really like to implement : when a `virus `is eaten, instead of being deleted, it only changes its `position`. Now, I want to prevent the new position to be into a cell. How can I make sure to respawn a virus without being caught in a while true?

2. I'm trying to figure out how to test the respawn function... Do you have an idea?

Please make suggestions because I wiped this PR three times before having this result. 

Closing #266 