### PR TITLE
Tweaks acceleration + radius

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -26,7 +26,7 @@ object Cell {
   /**
     * Ratio of impact of the mass on the acceleration.
     */
-  final val MassImpactOnAcceleration = 0.666f
+  final val MassImpactOnAcceleration = 0.75f
 }
 
 class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f, 0f)) {

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -24,7 +24,7 @@ object Cell {
   final val MassDecayPerSecond = 0.005f
 
   /**
-    * Ratio of impact of the mass on the acceleration.
+    * Exponent used on the mass when calculating the acceleration of a cell.
     */
   final val MassImpactOnAcceleration = 0.75f
 }

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -22,6 +22,11 @@ object Cell {
    * Ratio of mass lost per second.
    */
   final val MassDecayPerSecond = 0.005f
+
+  /**
+    * Ratio of impact of the mass on the acceleration.
+    */
+  final val MassImpactOnAcceleration = 0.666f
 }
 
 class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f, 0f)) {
@@ -48,7 +53,7 @@ class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f,
   }
 
   def radius: Double = {
-    sqrt(mass * Pi)
+    4 + sqrt(mass) * 3
   }
 
   def update(deltaSeconds: Float, grid: Grid): Unit = {
@@ -79,7 +84,7 @@ class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f,
 
   def acceleration: Vector2 = {
     val dir = target - position
-    val value = Cell.MovementForce / mass
+    val value = Cell.MovementForce / pow(mass, Cell.MassImpactOnAcceleration).toFloat
     if (dir.magnitude > 0) dir.normalize * value else new Vector2(0f,0f)
   }
 
@@ -104,7 +109,7 @@ class Cell(val id: Int, player: Player, startPosition: Vector2 = new Vector2(0f,
 
   def state: serializable.Cell = {
     serializable.Cell(id,
-                      round(mass).toInt,
+                      round(mass),
                       round(radius).toInt,
                       position.state,
                       target.state)

--- a/game/src/test/scala/io/aigar/game/AIStateSpec.scala
+++ b/game/src/test/scala/io/aigar/game/AIStateSpec.scala
@@ -40,7 +40,7 @@ class AIStateSpec extends FlatSpec with Matchers {
   "WanderingState" should "keep the current cell's target on creation" in {
     val player = new Player(0, Vector2(0f, 0f))
     val cell = player.cells.head
-    cell.target = Vector2(10f, 10f)
+    cell.target = Vector2(100f, 100f)
     player.aiState = new WanderingState(player)
 
     val target = player.aiState.update(1f, new Grid(0, 0), cell)


### PR DESCRIPTION
Tweaks both of them.

Acceleration was previously influenced by `mass`, I tried with `sqrt(mass)` but it was not enough. I've put `pow(mass, 0.75)` so it feels like the right fit right now.

With the `MaxSpeed` tweak, everything will be perfect. 

Closes #251