### PR TITLE
Cell methods for actions

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -80,6 +80,7 @@ To eat an enemy cell, a cell must almost completely overlap its enemy and be
           The bigger the mass, the bigger the cell, the slower the cell can move
           or accelerate.
           Mass decays over time (by a ratio of the current mass).
+          The minimal mass of a cell is `20`.
 
 - `radius`: Radius of the cell, influenced by its current mass
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -88,6 +88,29 @@ To eat an enemy cell, a cell must almost completely overlap its enemy and be
 - `target`: Target (`Vec2` object) that the cell should go for.
             Move the cell by changing this value.
 
+#### Methods
+*Note: the following methods will only have an effect when called on cells
+       owned by your player.*
+
+- `move(target)`: Moves towards the given `Vec2` target.
+                  Convenience method that sets `cell.target`.
+
+- `split()`: Splits the cell into two distinct cells with half their parent's
+             mass. The new cells will later be available to control via the
+             `cells` list in `Player`.
+             The cell must be at least twice the minimum mass for this call to
+             have an effect.
+
+- `burst()`: Exchanges a fixed amount of the cell's mass to gain a temporary
+             speed boost.
+             If the cell is too small to afford the price, this call has no
+             effect.
+
+- `trade(mass)`: Trades a given amount of the cell's mass to gain a small gain
+                 in the player's score (competition points).
+                 If the given quantity is too large for the cell's mass, the
+                 trade will only be based on how much the cell can afford.
+
 
 ### Resources
 Contains the information about the resources available on the map. Collecting

--- a/clients/python/game/api.py
+++ b/clients/python/game/api.py
@@ -40,12 +40,3 @@ class API:
         Extracts the application data from a requests Response object.
         """
         return response.json()["data"]
-
-
-class CellActions:
-    def __init__(self, cell_id, target, burst, split, trade):
-        self.cell_id = cell_id
-        self.target = target
-        self.burst = burst
-        self.split = split
-        self.trade = trade

--- a/clients/python/game/game_loop.py
+++ b/clients/python/game/game_loop.py
@@ -1,0 +1,16 @@
+def update_game(api, game_id, step_fn):
+    """
+    Takes care of doing one update tick:
+    - fetch the game state
+    - call the player's AI
+    - send actions chosen by AI
+
+    :param api: API object to communicate with the server
+    :param game_id: ID of the game that we're playing
+    :param step_fn: function to call to execute the player's AI
+    """
+    game = api.fetch_game_state(game_id)
+
+    step_fn(game)
+
+    api.send_actions(game_id, [cell.actions() for cell in game.me.cells])

--- a/clients/python/game/game_loop_test.py
+++ b/clients/python/game/game_loop_test.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+from planar import Vec2
+
+from .game_loop import update_game
+from .models import Game, Cell, Player, Map, Resources
+
+
+class GameLoopTests(TestCase):
+    def test_update_game_calls_send_actions(self):
+        cells = [Cell(0, 5, 10, Vec2(0, 0), Vec2(1, 1)),
+                 Cell(1, 5, 10, Vec2(0, 0), Vec2(1, 1))]
+        player = Player(0, "", 10, True, cells)
+        game = Game(0, 0, 0, [player], Resources([], [], []), Map(0, 0), [])
+
+        cells[0].target = Vec2(2, 2)
+        cells[0].burst()
+
+        cells[1].split()
+        cells[1].trade(3)
+
+        class MockApi:
+            def fetch_game_state(self, game_id):
+                return game
+
+            def send_actions(self, game_id, actions):
+                self.actions = actions
+
+        api = MockApi()
+
+        update_game(api, 0, lambda x: None)
+
+        self.assertTrue(
+            api.actions[0].target.almost_equals(Vec2(2, 2)))
+        self.assertTrue(api.actions[0].burst)
+
+        self.assertTrue(api.actions[1].split)
+        self.assertEqual(3, api.actions[1].trade)

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -99,6 +99,9 @@ class Cell:
 
         self._actions = CellActions(self.id)
 
+    def move(self, target):
+        self.target = target
+
     def split(self):
         self._actions.split = True
 

--- a/clients/python/game/models.py
+++ b/clients/python/game/models.py
@@ -97,6 +97,17 @@ class Cell:
         self.position = position
         self.target = target
 
+        self._actions = CellActions(self.id)
+
+    def split(self):
+        self._actions.split = True
+
+    def burst(self):
+        self._actions.burst = True
+
+    def trade(self, quantity):
+        self._actions.trade = quantity
+
     def parse(obj):
         return Cell(
                 obj["id"],
@@ -110,6 +121,14 @@ class Cell:
         return ("#%d (%d) %s -> %s" %
                 (self.id, self.mass,
                  format_vec2(self.position), format_vec2(self.target)))
+
+    def actions(self):
+        actions = self._actions
+        actions.target = self.target
+
+        self._actions = CellActions(self.id)
+
+        return actions
 
 
 class Resources:
@@ -143,6 +162,15 @@ class Virus:
 
     def __str__(self):
         return format_vec2(self.position)
+
+
+class CellActions:
+    def __init__(self, cell_id):
+        self.cell_id = cell_id
+        self.target = None
+        self.burst = False
+        self.split = False
+        self.trade = 0
 
 
 def parse_vec2(obj):

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -159,6 +159,14 @@ class CellTests(TestCase):
         self.assertTrue(cell.position.almost_equals(Vec2(1241, 442)))
         self.assertTrue(cell.target.almost_equals(Vec2(1448, 1136)))
 
+    def test_move_sets_target(self):
+        cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
+
+        target = Vec2(8, 9)
+        cell.move(target)
+
+        self.assertEqual(target, cell.target)
+
     def test_actions_sets_actions_target(self):
         cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
 

--- a/clients/python/game/models_test.py
+++ b/clients/python/game/models_test.py
@@ -159,6 +159,38 @@ class CellTests(TestCase):
         self.assertTrue(cell.position.almost_equals(Vec2(1241, 442)))
         self.assertTrue(cell.target.almost_equals(Vec2(1448, 1136)))
 
+    def test_actions_sets_actions_target(self):
+        cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
+
+        actions = cell.actions()
+
+        self.assertEqual(1, actions.cell_id)
+        self.assertTrue(Vec2(6, 7).almost_equals(actions.target))
+
+    def test_split_sets_actions_split(self):
+        cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
+
+        cell.split()
+
+        actions = cell.actions()
+        self.assertTrue(actions.split)
+
+    def test_burst_sets_actions_burst(self):
+        cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
+
+        cell.burst()
+
+        actions = cell.actions()
+        self.assertTrue(actions.burst)
+
+    def test_trade_sets_actions_trade(self):
+        cell = Cell(1, 2, 3, Vec2(4, 5), Vec2(6, 7))
+
+        cell.trade(42)
+
+        actions = cell.actions()
+        self.assertEqual(42, actions.trade)
+
 
 class ResourcesTests(TestCase):
     def test_parse(self):

--- a/clients/python/play.py
+++ b/clients/python/play.py
@@ -2,6 +2,7 @@ from time import sleep
 import json
 import sys
 
+from game.game_loop import update_game
 from game.api import API
 from game.models import Game
 from ai import step
@@ -17,11 +18,7 @@ def main():
     api = API(player_id, player_secret)
 
     while True:
-        game = api.fetch_game_state(game_id)
-
-        step(game)
-
-        api.send_actions(game_id, [cell.actions() for cell in game.me.cells])
+        update_game(api, game_id, step)
 
         sleep(1 / UpdatesPerSecond)
 

--- a/clients/python/play.py
+++ b/clients/python/play.py
@@ -1,9 +1,8 @@
 from time import sleep
 import json
 import sys
-from planar import Vec2
 
-from game.api import API, CellActions
+from game.api import API
 from game.models import Game
 from ai import step
 
@@ -22,9 +21,7 @@ def main():
 
         step(game)
 
-        api.send_actions(game_id,
-                         [CellActions(game.me.cells[0].id,
-                          Vec2(0, 0), False, False, 0)])
+        api.send_actions(game_id, [cell.actions() for cell in game.me.cells])
 
         sleep(1 / UpdatesPerSecond)
 

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -15,6 +15,8 @@ object Cell {
 
   /**
    * Default mass of a cell (at spawn).
+   *
+   * IMPORTANT must stay in sync with the client's documentation
    */
   final val MinMass = 20f
 


### PR DESCRIPTION
Convenience methods to call actions on a cell, e.g.:
```py
// ...
cell1.move(opponent.position)
// ...
cell2.split()
// ...
cell3.trade(1)
// ...
```
Then, the game loop takes care of gathering the flags/values that were set and send those over as actions.

Given #284 , I did not add `feed()` for now.