### PR TITLE
Simplify physics (make cells reach their targets)

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -2,7 +2,7 @@ package io.aigar.game
 
 import io.aigar.controller.response.Action
 import scala.math.{max, round, pow}
-import io.aigar.game.Vector2Utils.StateAddon
+import io.aigar.game.Vector2Utils.Vector2Addons
 import io.aigar.game.Position2Utils.PositionAddon
 import com.github.jpbetz.subspace.Vector2
 import scala.math._

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -88,7 +88,7 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
   }
 
   /**
-   * Returns a steering force (unbounded) towards the target of the cell.
+   * Returns a steering force (unbounded) towards the target velocity
    */
   def steering: Vector2 = {
     val dir = target - position

--- a/game/src/main/scala/io/aigar/game/Vector2Utils.scala
+++ b/game/src/main/scala/io/aigar/game/Vector2Utils.scala
@@ -12,6 +12,10 @@ object Vector2Utils {
     def truncate(length: Float): Vector2 = {
       if (vector.magnitude > length) vector.normalize * length else vector
     }
+
+    def safeNormalize: Vector2 = {
+      if (vector.magnitude > 0f) vector.normalize else vector
+    }
   }
 }
 

--- a/game/src/main/scala/io/aigar/game/Vector2Utils.scala
+++ b/game/src/main/scala/io/aigar/game/Vector2Utils.scala
@@ -4,9 +4,13 @@ import com.github.jpbetz.subspace._
 import io.aigar.game.serializable.Position
 
 object Vector2Utils {
-  implicit class StateAddon(val vector: Vector2) {
+  implicit class Vector2Addons(val vector: Vector2) {
     def state = {
       serializable.Position(vector.x, vector.y)
+    }
+    
+    def truncate(length: Float): Vector2 = {
+      if (vector.magnitude > length) vector.normalize * length else vector
     }
   }
 }

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -2,7 +2,7 @@ package io.aigar.game
 
 import com.github.jpbetz.subspace.Vector2
 import io.aigar.game.serializable.Position
-import io.aigar.game.Vector2Utils.StateAddon
+import io.aigar.game.Vector2Utils.Vector2Addons
 
 object Virus {
   final val Quantity = 15

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -25,13 +25,9 @@ class CellSpec extends FlatSpec with Matchers {
     cell.target = new Vector2(1000f, 1000f)
     val grid = new Grid(100, 100)
 
-    val initialDistance = cell.position.distanceTo(cell.target)
-
     cell.update(1f, grid)
 
-    val finalDistance = cell.position.distanceTo(cell.target)
-
-    initialDistance should be > finalDistance
+    cell.velocity.magnitude should be > 0f
   }
 
   it should "have a maximal velocity" in {
@@ -55,24 +51,10 @@ class CellSpec extends FlatSpec with Matchers {
     small.mass = Cell.MinMass
     big.mass = 100 * Cell.MinMass
 
-    small.acceleration.magnitude should be > big.acceleration.magnitude
-  }
-
-  it should "not move slower than the minimal speed limit, no matter what its mass is" in {
-    val player = new Player(0, Vector2(0f, 0f))
-    val small = new Cell(1, player)
-    small.target = new Vector2(100f, 100f)
-    val big = new Cell(2, player)
-    big.target = new Vector2(100f, 100f)
-    player.cells = List(small, big)
-
-    small.mass = Cell.MinMass
-    big.mass = 100 * Cell.MinMass
-
     small.maxSpeed should be > big.maxSpeed
   }
 
-  it should "not move slower than the minimal speed no matter its mass" in {
+  it should "not move slower than the minimal speed limit, no matter what its mass is" in {
     val player = new Player(0, Vector2(0f, 0f))
     val big = new Cell(2, player)
     player.cells = List(big)
@@ -232,54 +214,50 @@ class CellSpec extends FlatSpec with Matchers {
     cell.position.y should be <= 10f
   }
 
-  it should "resets its X velocity when having a collision with the max horizontal boundary" in {
+  it should "reset its X velocity when having a collision with the max horizontal boundary" in {
     val player = new Player(1, new Vector2(10, 5))
     val cell = player.cells.head
     val grid = new Grid(10, 10)
 
     cell.velocity = new Vector2(15, 5)
-    cell.target = new Vector2(15, 5)
 
-    cell.update(0.005f, grid)
+    cell.keepInGrid(grid)
 
     cell.velocity.x should equal(0)
   }
 
-  it should "resets its X velocity when having a collision with the min horizontal boundary" in {
+  it should "reset its X velocity when having a collision with the min horizontal boundary" in {
     val player = new Player(1, new Vector2(0, 5))
     val cell = player.cells.head
     val grid = new Grid(10, 10)
 
     cell.velocity = new Vector2(-5, 5)
-    cell.target = new Vector2(-5, 5)
 
-    cell.update(0.005f, grid)
+    cell.keepInGrid(grid)
 
     cell.velocity.x should equal(0)
   }
 
-  it should "resets its Y velocity when having a collision with the max vertical boundary" in {
+  it should "reset its Y velocity when having a collision with the max vertical boundary" in {
     val player = new Player(1, new Vector2(5, 10))
     val cell = player.cells.head
     val grid = new Grid(10, 10)
 
     cell.velocity = new Vector2(5, 15)
-    cell.target = new Vector2(5, 15)
 
-    cell.update(0.005f, grid)
+    cell.keepInGrid(grid)
 
     cell.velocity.y should equal(0)
   }
 
-  it should "resets its Y velocity when having a collision with the min vertical boundary" in {
+  it should "reset its Y velocity when having a collision with the min vertical boundary" in {
     val player = new Player(1, new Vector2(5, 0))
     val cell = player.cells.head
     val grid = new Grid(10, 10)
 
     cell.velocity = new Vector2(5, -5)
-    cell.target = new Vector2(5, -5)
 
-    cell.update(0.005f, grid)
+    cell.keepInGrid(grid)
 
     cell.velocity.y should equal(0)
   }

--- a/game/src/test/scala/io/aigar/game/GameSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameSpec.scala
@@ -52,13 +52,9 @@ class GameSpec extends FlatSpec with Matchers {
     cell.position = Vector2(0, 0)
     cell.target = new Vector2(100f, 100f)
 
-    val initialDistance = cell.position.distanceTo(cell.target)
-
     game.update(1f)
 
-    val finalDistance = cell.position.distanceTo(cell.target)
-
-    initialDistance should be > finalDistance
+    cell.velocity.magnitude should be > 0f
   }
 
   it should "create a bigger grid if there are more players" in {

--- a/game/src/test/scala/io/aigar/game/PlayerSpec.scala
+++ b/game/src/test/scala/io/aigar/game/PlayerSpec.scala
@@ -12,19 +12,15 @@ class PlayerSpec extends FlatSpec with Matchers {
     player.cells.loneElement.position should equal(new Vector2(42f, 42f))
   }
 
-  it should "move its cells on update" in {
+  it should "move its cells on updates" in {
     val player = new Player(0, new Vector2(0f, 0f))
     val target = new Vector2(100f, 100f)
     player.cells.head.target = target
     val grid = new Grid(100, 100)
 
-    val initialDistance = player.cells.head.position.distanceTo(target)
+    player.update(1f, grid, List(player))
 
-    player.update(1f, grid, List(new Player(0, new Vector2(0, 0))))
-
-    val finalDistance = player.cells.head.position.distanceTo(target)
-
-    initialDistance should be > finalDistance
+    player.cells.head.velocity.magnitude should be > 0f
   }
 
   it should "generate a state with the right info" in {

--- a/game/src/test/scala/io/aigar/game/Vector2UtilsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/Vector2UtilsSpec.scala
@@ -31,6 +31,18 @@ class Vector2UtilsSpec extends FlatSpec with Matchers {
     truncated should be theSameInstanceAs(vector)
   }
 
+  it should "not crash when calling safeNormalize on a zero vector" in {
+    val vector = new Vector2(0f, 0f)
+
+    vector.safeNormalize should equal(vector)
+  }
+
+  it should "return a normalized vector for non-zero vectors" in {
+    val vector = new Vector2(100f, 98f)
+
+    vector.safeNormalize should equal(vector.normalize)
+  }
+
   "Position" should "generate a vector with the right coordinates" in {
     val position = new Position(100f, 200f)
 

--- a/game/src/test/scala/io/aigar/game/Vector2UtilsSpec.scala
+++ b/game/src/test/scala/io/aigar/game/Vector2UtilsSpec.scala
@@ -14,6 +14,23 @@ class Vector2UtilsSpec extends FlatSpec with Matchers {
     state.y should equal(200f)
   }
 
+  it should "truncate a long vector" in {
+    val vector = new Vector2(100f, 0f)
+
+    val truncated = vector.truncate(5f)
+
+    truncated.x should equal(5f)
+    truncated.y should equal(0f)
+  }
+
+  it should "not truncate a short vector" in {
+    val vector = new Vector2(1f, 1f)
+
+    val truncated = vector.truncate(5f) 
+
+    truncated should be theSameInstanceAs(vector)
+  }
+
   "Position" should "generate a vector with the right coordinates" in {
     val position = new Position(100f, 200f)
 


### PR DESCRIPTION
Closes #286 .

I used the chapter about steering behaviors in the *AI For Games* book that I own. The model that we had before (with forces and accelerations) is *part* of what is used when simulating complex entities such as cars. In our case, we just want the input to feel responsive. Therefore, we remove the part dealing with forces (which means that all cells accelerate at the same speed, no matter what their mass is).

- Note that the physics feels much different now (it feels faster). Personally, I like the results (although maybe we'd need to tweak the interpolation refresh rate to make it smoother).
- Since the only different thing between small and big cells is now their max speed, I made that change feel heavier for big cells.
- I changed the order of update of `position` and `velocity` to make sure it matches the ordering in the book (and I found some StackOverflow answers that specifically recommended that I believe), so I had to update some tests accordingly.
- I added some addons to `Vector2` to make it more pleasant to work with.
- I removed a test that looked like a duplicate in `CellSpec`
