### PR TITLE
Require 85% overlap to collide

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -101,10 +101,6 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     targetVelocity - velocity
   }
 
-  def contains(pos: Vector2): Boolean = {
-    position.distanceTo(pos) <= radius
-  }
-
   def performAction(action: Action): Unit = {
     target = action.target.toVector
   }

--- a/game/src/main/scala/io/aigar/game/Entity.scala
+++ b/game/src/main/scala/io/aigar/game/Entity.scala
@@ -1,6 +1,21 @@
 package io.aigar.game
 
 import com.github.jpbetz.subspace.Vector2
+import io.aigar.game.Vector2Utils.Vector2Addons
+
+object Entity {
+  /**
+   * How much (ratio) of an entity's diameter must be covered by another entity
+   * to consider that it is being overlapped.
+   */
+  val OverlappingRatio = 0.8f
+
+  /**
+   * Ratio of the diameter to reach the middle of an entity. Use this value to
+   * require overlapping only the center of an entity.
+   */
+  val CenterRatio = 0.5f
+}
 
 trait Entity {
   var position: Vector2
@@ -12,5 +27,18 @@ trait Entity {
   def mass: Float = _mass
   def mass_=(m: Float): Unit = {
     _mass = m
+  }
+
+  def radius: Float
+
+  def overlaps(other: Entity): Boolean = {
+    val dir = (other.position - position).safeNormalize
+    val ratioPastCenter = Entity.OverlappingRatio - Entity.CenterRatio
+    val target = other.position + dir * ratioPastCenter
+    contains(target)
+  }
+
+  def contains(pos: Vector2): Boolean = {
+    position.distanceTo(pos) <= radius
   }
 }

--- a/game/src/main/scala/io/aigar/game/Entity.scala
+++ b/game/src/main/scala/io/aigar/game/Entity.scala
@@ -8,7 +8,7 @@ object Entity {
    * How much (ratio) of an entity's diameter must be covered by another entity
    * to consider that it is being overlapped.
    */
-  val OverlappingRatio = 0.8f
+  val OverlappingRatio = 0.85f
 
   /**
    * Ratio of the diameter to reach the middle of an entity. Use this value to

--- a/game/src/main/scala/io/aigar/game/EntityContainer.scala
+++ b/game/src/main/scala/io/aigar/game/EntityContainer.scala
@@ -33,7 +33,7 @@ trait EntityContainer {
     for (entity <- entities){
       for (player <- players) {
         for (cell <- player.cells) {
-          if (cell.contains(entity.position)) {
+          if (cell.overlaps(entity)) {
             entitiesReturn :::= onCellCollision(cell, player, entity, scoreModifications)
           }
         }

--- a/game/src/main/scala/io/aigar/game/Resources.scala
+++ b/game/src/main/scala/io/aigar/game/Resources.scala
@@ -117,6 +117,8 @@ class Resource(var position: Vector2 = new Vector2(0f, 0f),
                val scoreModification: Int = 0) extends Entity {
   _mass = resourceMass
 
+  def radius: Float = 1
+
   def state: Vector2 = {
     position
   }

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -22,7 +22,7 @@ object Virus {
 class Virus(var position: Vector2 = new Vector2(0f, 0f)) extends Entity {
   _mass = Virus.Mass
   val scoreModification = 0
-  val radius = Cell.radius(mass)
+  def radius: Float = Cell.radius(mass)
 
   def state: serializable.Virus = {
     serializable.Virus(position.state,

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -77,23 +77,6 @@ class CellSpec extends FlatSpec with Matchers {
     state.radius should equal(round(cell.radius).toInt)
   }
 
-  it should "Be in the cell" in {
-    val player = new Player(0, Vector2(0f, 0f))
-    val cell = player.cells.head
-    cell.mass = (pow(100f, 2) / Pi).toFloat
-
-    val vec = new Vector2(42f, 42f)
-    cell.contains(vec) should equal(true)
-  }
-  it should "Not be in the cell" in {
-    val player = new Player(0, Vector2(0f, 0f))
-    val cell = player.cells.head
-    cell.mass = Cell.MinMass
-
-    val vec = new Vector2(42f, 42f)
-    cell.contains(vec) should equal(false)
-  }
-
   it should "not move without setting its target" in {
     val player = new Player(0, Vector2(42f, 42f))
     val cell = player.cells.head

--- a/game/src/test/scala/io/aigar/game/EntitySpec.scala
+++ b/game/src/test/scala/io/aigar/game/EntitySpec.scala
@@ -1,0 +1,56 @@
+import io.aigar.game._
+import org.scalatest._
+import com.github.jpbetz.subspace._
+
+class EntitySpec extends FlatSpec with Matchers {
+  class FakeEntity(rad: Float, pos: Vector2 = Vector2(0f, 0f)) extends Entity {
+    def radius: Float = rad
+    def position: Vector2 = pos
+    def position_=(v: Vector2) {}
+    val scoreModification: Int = 0
+  }
+
+  "An Entity" should "contain a position inside its radius" in {
+    val entity = new FakeEntity(100f)
+
+    val vec = Vector2(50f, 0f)
+
+    entity.contains(vec) should equal(true)
+  }
+
+  it should "not contain a position outside of its radius" in {
+    val entity = new FakeEntity(1f)
+
+    val vec = Vector2(50f, 0f)
+
+    entity.contains(vec) should not be(true)
+  }
+
+  it should "overlap a fully contained entity" in {
+    val container = new FakeEntity(100f)
+    val contained = new FakeEntity(1f)
+
+    container.overlaps(contained) should be(true)
+  }
+
+  it should "not overlap an entity that does not collide" in {
+    val current = new FakeEntity(100f)
+    val far = new FakeEntity(1f, Vector2(300f, 300f))
+
+    current.overlaps(far) should not be(true)
+  }
+
+  it should "not overlap when it barely collides with another entity's center" in {
+    val current = new FakeEntity(100f)
+    val other = new FakeEntity(100f, Vector2(100f, 0f))
+
+    current.overlaps(other) should not be(true)
+  }
+
+  it should "overlap when almost fully covers another entity" in {
+    val current = new FakeEntity(100f)
+    val other = new FakeEntity(55f, Vector2(50f, 0f))
+
+    current.overlaps(other) should be(true)
+  }
+}


### PR DESCRIPTION
Closes #260 .

Based on how much a cell is overlapping another cell's diameter. Right now, we need to overlap by 85% to collide. At first glance, I preferred this to the old behaviour.