### PR TITLE
Fixes the Windows start script

### DIFF
--- a/bin/install.bat
+++ b/bin/install.bat
@@ -1,3 +1,3 @@
 cd ../web
-npm run build
+npm install
 cd ../bin

--- a/bin/start.bat
+++ b/bin/start.bat
@@ -12,6 +12,8 @@ if not "%~1"=="-p" goto UNKNOWN
 
 set PREFIX_PATH=%2
 set CONFIG_PATH=%2/nginx.conf
+
+start install.bat
 start build.bat
 start sbt.bat
 


### PR DESCRIPTION
The command `npm run build` was never executed. We had to manually refresh the javascript files.