### PR TITLE
Action trade mass

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -108,7 +108,8 @@ To eat an enemy cell, a cell must almost completely overlap its enemy and be
              effect.
 
 - `trade(mass)`: Trades a given amount of the cell's mass to gain a small gain
-                 in the player's score (competition points).
+                 in the player's score (competition points) with a ratio of 
+                 2:1.
                  If the given quantity is too large for the cell's mass, the
                  trade will only be based on how much the cell can afford.
 

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -27,6 +27,13 @@ object Cell {
    */
   final val MassDominanceRatio = 1.1f
 
+  /**
+    * How much a unit of mass represent when traded for score
+    *
+    * IMPORTANT keep this value in sync with the client documentation
+    */
+  final val MassToScoreRatio = 0.5f
+
   final val MinMaximumSpeed = 25f
   final val MaxMaximumSpeed = 50f
   final val SpeedLimitReductionPerMassUnit = 0.02f
@@ -105,8 +112,8 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     target = action.target.toVector
 
     if (action.split) split
-
-    if (action.trade > 0 && mass > 2 * Cell.MinMass) {
+    val massToTrade = action.trade
+    if (massToTrade > 0 && mass - massToTrade >= Cell.MinMass) {
       return Some(tradeMass(action.trade))
     }
     return None
@@ -126,8 +133,8 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
   }
 
   def tradeMass(massToTrade: Int): ScoreModification = {
-    mass = mass / 2
-    new ScoreModification(player.id, massToTrade / 2)
+    mass = mass - massToTrade
+    new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio)
   }
 
   def state: serializable.Cell = {

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -112,9 +112,9 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     target = action.target.toVector
 
     if (action.split) split
-    val massToTrade = action.trade
+    val massToTrade = min(action.trade, max(mass - Cell.MinMass, 0)).toInt
     if (massToTrade > 0 && mass - massToTrade >= Cell.MinMass) {
-      return Some(tradeMass(action.trade))
+      return Some(tradeMass(massToTrade))
     }
     return None
   }
@@ -133,7 +133,7 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
   }
 
   def tradeMass(massToTrade: Int): ScoreModification = {
-    mass = mass - massToTrade
+    mass -= massToTrade
     new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio)
   }
 

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -112,11 +112,8 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     target = action.target.toVector
 
     if (action.split) split
-    val massToTrade = min(action.trade, max(mass - Cell.MinMass, 0)).toInt
-    if (massToTrade > 0 && mass - massToTrade >= Cell.MinMass) {
-      return Some(tradeMass(massToTrade))
-    }
-    return None
+    val modifications = tradeMass(action.trade)
+    modifications
   }
 
   def split(): Unit = {
@@ -132,9 +129,16 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     other.position += Vector2(radius * 2f, radius * 2f) // TODO replace this with a pushing force
   }
 
-  def tradeMass(massToTrade: Int): ScoreModification = {
-    mass -= massToTrade
-    new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio)
+  def tradeMass(massToTrade: Int): Option[ScoreModification] = {
+
+    val amount = min(massToTrade, max(mass - Cell.MinMass, 0)).toInt
+
+    if (amount > 0 && mass - amount >= Cell.MinMass) {
+      mass -= amount
+      return Some(ScoreModification(player.id, amount * Cell.MassToScoreRatio))
+    }
+
+    None
   }
 
   def state: serializable.Cell = {

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -1,7 +1,7 @@
 package io.aigar.game
 
 import io.aigar.controller.response.Action
-import scala.math.{max, round, pow}
+import io.aigar.score.ScoreModification
 import io.aigar.game.Vector2Utils.Vector2Addons
 import io.aigar.game.Position2Utils.PositionAddon
 import com.github.jpbetz.subspace.Vector2
@@ -101,10 +101,15 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     targetVelocity - velocity
   }
 
-  def performAction(action: Action): Unit = {
+  def performAction(action: Action): Option[ScoreModification] = {
     target = action.target.toVector
 
     if (action.split) split
+
+    if (action.trade > 0 && mass > 2 * Cell.MinMass) {
+      return Some(tradeMass(action.trade))
+    }
+    return None
   }
 
   def split(): Unit = {
@@ -118,6 +123,11 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     mass /= 2f
 
     other.position += Vector2(radius * 2f, radius * 2f) // TODO replace this with a pushing force
+  }
+
+  def tradeMass(massToTrade: Int): ScoreModification = {
+    mass = mass / 2
+    new ScoreModification(player.id, massToTrade / 2)
   }
 
   def state: serializable.Cell = {

--- a/game/src/main/scala/io/aigar/game/EntityContainer.scala
+++ b/game/src/main/scala/io/aigar/game/EntityContainer.scala
@@ -36,8 +36,9 @@ trait EntityContainer {
       for (player <- players) {
         for (cell <- player.cells) {
           if (cell.overlaps(entity)) {
-            entitiesReturn ::= entity
-            modifications ::= onCellCollision(cell, player, entity)
+            val (entitiesToRemove, modificationsToAdd) = onCellCollision(cell, player, entity)
+            entitiesReturn :::= entitiesToRemove
+            modifications ::= modificationsToAdd
           }
         }
       }
@@ -47,5 +48,5 @@ trait EntityContainer {
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity): ScoreModification
+                      entity: Entity): (List[Entity], ScoreModification)
 }

--- a/game/src/main/scala/io/aigar/game/EntityContainer.scala
+++ b/game/src/main/scala/io/aigar/game/EntityContainer.scala
@@ -2,7 +2,6 @@ package io.aigar.game
 
 import com.github.jpbetz.subspace.Vector2
 import io.aigar.score.ScoreModification
-import scala.collection.mutable.MutableList
 
 trait EntityContainer {
   def shouldRespawn(size: Int, min: Int, max: Int): Boolean = {
@@ -29,23 +28,24 @@ trait EntityContainer {
   }
 
   def handleCollision(entities: List[Entity],
-                      players: List[Player],
-                      scoreModifications: Option[MutableList[ScoreModification]]): List[Entity] ={
+                      players: List[Player]): (List[Entity], List[ScoreModification]) ={
     var entitiesReturn = List[Entity]()
+    var modifications = List[ScoreModification]()
+
     for (entity <- entities){
       for (player <- players) {
         for (cell <- player.cells) {
           if (cell.overlaps(entity)) {
-            entitiesReturn :::= onCellCollision(cell, player, entity, scoreModifications)
+            entitiesReturn ::= entity
+            modifications ::= onCellCollision(cell, player, entity)
           }
         }
       }
     }
-    entities diff entitiesReturn
+    (entities diff entitiesReturn, modifications)
   }
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity,
-                      scoreModifications: Option[MutableList[ScoreModification]]): List[Entity]
+                      entity: Entity): ScoreModification
 }

--- a/game/src/main/scala/io/aigar/game/EntityContainer.scala
+++ b/game/src/main/scala/io/aigar/game/EntityContainer.scala
@@ -28,7 +28,7 @@ trait EntityContainer {
   }
 
   def handleCollision(entities: List[Entity],
-                      players: List[Player]): (List[Entity], List[ScoreModification]) ={
+                      players: List[Player]): (List[Entity], List[ScoreModification]) = {
     var entitiesReturn = List[Entity]()
     var modifications = List[ScoreModification]()
 

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -32,11 +32,15 @@ class Game(val id: Int, playerIDs: List[Int], val duration: Int = Game.DefaultDu
     scoreModifications
   }
 
-  def performAction(player_id: Int, actions: List[Action]): Unit = {
+  def performAction(player_id: Int, actions: List[Action]): List[ScoreModification] = {
+    var modifications = List[ScoreModification]()
     players.find(_.id == player_id) match {
-      case Some(player) => player.performAction(actions)
-      case None => {}
+      case Some(player) => {
+        modifications = player.performAction(actions)
+      }
+      case None =>
     }
+    modifications
   }
 
   def state = {

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -23,9 +23,7 @@ class Game(val id: Int, playerIDs: List[Int], val duration: Int = Game.DefaultDu
   var tick = 0
 
   def update(deltaSeconds: Float): List[ScoreModification] = {
-    var modifications = List[ScoreModification]()
-
-    players.foreach { player => modifications :::= player.update(deltaSeconds, grid, players) }
+    var modifications = players.flatten {  _.update(deltaSeconds, grid, players) }
     modifications :::= viruses.update(grid, players)
     modifications :::= resources.update(grid, players)
     tick += 1

--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -3,7 +3,6 @@ package io.aigar.game
 import com.typesafe.scalalogging.LazyLogging
 import io.aigar.score.ScoreModification
 import io.aigar.controller.response.Action
-import scala.collection.mutable.MutableList
 
 /**
  * Game holds the logic for an individual game being played
@@ -23,13 +22,15 @@ class Game(val id: Int, playerIDs: List[Int], val duration: Int = Game.DefaultDu
   val startTime = GameThread.time
   var tick = 0
 
-  def update(deltaSeconds: Float): MutableList[ScoreModification] = {
-    players.foreach { player => player.update(deltaSeconds, grid, players) }
-    viruses.update(grid, players)
-    val scoreModifications = resources.update(grid, players)
+  def update(deltaSeconds: Float): List[ScoreModification] = {
+    var modifications = List[ScoreModification]()
+
+    players.foreach { player => modifications :::= player.update(deltaSeconds, grid, players) }
+    modifications :::= viruses.update(grid, players)
+    modifications :::= resources.update(grid, players)
     tick += 1
 
-    scoreModifications
+    modifications
   }
 
   def performAction(player_id: Int, actions: List[Action]): List[ScoreModification] = {

--- a/game/src/main/scala/io/aigar/game/GameThread.scala
+++ b/game/src/main/scala/io/aigar/game/GameThread.scala
@@ -64,10 +64,17 @@ class GameThread(scoreThread: ScoreThread, playerIDs: List[Int]) extends Runnabl
   }
 
   def transferActions: Unit = {
-    while(!actionQueue.isEmpty) {
+    while (!actionQueue.isEmpty) {
       val action = actionQueue.take
       games.find(_.id == action.game_id) match {
-        case Some(game) => game.performAction(action.player_id, action.actions)
+        case Some(game) => {
+          val modifications = game.performAction(action.player_id, action.actions)
+          if (game.id == Game.RankedGameId) {
+            modifications.foreach {
+              scoreThread.addScoreModification(_)
+            }
+          }
+        }
         case None =>
       }
     }

--- a/game/src/main/scala/io/aigar/game/Player.scala
+++ b/game/src/main/scala/io/aigar/game/Player.scala
@@ -82,15 +82,20 @@ class Player(val id: Int, startPosition: Vector2) extends EntityContainer
     )
   }
 
-  def performAction(actions: List[Action]): Unit = {
+  def performAction(actions: List[Action]): List[ScoreModification] = {
     onExternalAction
 
+    var modifications = List[ScoreModification]()
     actions.foreach {
       action => cells.find(_.id == action.cell_id) match {
-        case Some(cell) => cell.performAction(action)
+        case Some(cell) => cell.performAction(action) match {
+          case Some(modification) => modifications :::= List(modification)
+          case None =>
+        }
         case None =>
       }
     }
+    modifications
   }
 
   /**

--- a/game/src/main/scala/io/aigar/game/Resources.scala
+++ b/game/src/main/scala/io/aigar/game/Resources.scala
@@ -83,10 +83,9 @@ class ResourceType(grid: Grid,
   var resources = List.fill(resourceMax)(new Resource(grid.randomPosition, resourceMass, resourceScore))
 
   def update(grid: Grid, players: List[Player]): List[ScoreModification] = {
-    val tupleReturn = handleCollision(resources, players)
+    val (resourcesReturn, modifications) = handleCollision(resources, players)
 
-    resources = tupleReturn._1.asInstanceOf[List[Resource]]
-    val modifications = tupleReturn._2
+    resources = resourcesReturn.asInstanceOf[List[Resource]]
 
     if (shouldRespawn(resources.size, resourceMin, resourceMax)) {
       getRespawnPosition(grid, players, Resource.RespawnRetryAttempts) match {
@@ -99,9 +98,9 @@ class ResourceType(grid: Grid,
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity): ScoreModification = {
+                      entity: Entity): (List[Entity], ScoreModification) = {
     reward(cell, entity.mass)
-    new ScoreModification(player.id, entity.scoreModification)
+    (List(entity), new ScoreModification(player.id, entity.scoreModification))
   }
 
   def randomPosition(grid: Grid): Vector2 = {

--- a/game/src/main/scala/io/aigar/game/Resources.scala
+++ b/game/src/main/scala/io/aigar/game/Resources.scala
@@ -2,7 +2,6 @@ package io.aigar.game
 
 import com.github.jpbetz.subspace.Vector2
 import io.aigar.score.ScoreModification
-import scala.collection.mutable.MutableList
 
 object Resource {
   final val RespawnRetryAttempts = 10
@@ -59,11 +58,11 @@ class Resources(grid: Grid) {
   )
   val resourceTypes = List(regulars, silvers, golds)
 
-  def update(grid: Grid, players: List[Player]): MutableList[ScoreModification] = {
-    val scoreModifications = MutableList[ScoreModification]()
-    resourceTypes.foreach { _.update(grid, players, scoreModifications) }
+  def update(grid: Grid, players: List[Player]): List[ScoreModification] = {
+    var modifications = List[ScoreModification]()
+    resourceTypes.foreach { modifications :::= _.update(grid, players) }
 
-    scoreModifications
+    modifications
   }
 
   def state: serializable.Resources = {
@@ -83,24 +82,26 @@ class ResourceType(grid: Grid,
                   ) extends EntityContainer {
   var resources = List.fill(resourceMax)(new Resource(grid.randomPosition, resourceMass, resourceScore))
 
-  def update(grid: Grid, players: List[Player], scoreModifications: MutableList[ScoreModification]): Unit = {
-    resources = handleCollision(resources, players, Some(scoreModifications)).asInstanceOf[List[Resource]]
+  def update(grid: Grid, players: List[Player]): List[ScoreModification] = {
+    val tupleReturn = handleCollision(resources, players)
+
+    resources = tupleReturn._1.asInstanceOf[List[Resource]]
+    val modifications = tupleReturn._2
 
     if (shouldRespawn(resources.size, resourceMin, resourceMax)) {
       getRespawnPosition(grid, players, Resource.RespawnRetryAttempts) match {
-        case Some(position) => resources :::= List(new Resource(position, resourceMass, resourceScore))
+        case Some(position) => resources ::= new Resource(position, resourceMass, resourceScore)
         case _ =>
       }
     }
+    modifications
   }
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity,
-                      scoreModifications: Option[MutableList[ScoreModification]]): List[Entity] = {
-    scoreModifications.get += ScoreModification(player.id, entity.scoreModification)
+                      entity: Entity): ScoreModification = {
     reward(cell, entity.mass)
-    List(entity)
+    new ScoreModification(player.id, entity.scoreModification)
   }
 
   def randomPosition(grid: Grid): Vector2 = {

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -36,10 +36,9 @@ class Viruses(grid: Grid) extends EntityContainer
   var viruses = List.fill(Virus.Max)(new Virus(grid.randomPosition))
 
   def update(grid: Grid, players: List[Player]): List[ScoreModification] = {
-    val tupleReturn = handleCollision(viruses, players)
+    val (virusesReturn, modifications) = handleCollision(viruses, players)
 
-    viruses = tupleReturn._1.asInstanceOf[List[Virus]]
-    val modifications = tupleReturn._2
+    viruses = virusesReturn.asInstanceOf[List[Virus]]
 
     if (shouldRespawn(viruses.size, Virus.Min, Virus.Max)) {
       getRespawnPosition(grid, players, Virus.RespawnRetryAttempts) match {
@@ -52,14 +51,16 @@ class Viruses(grid: Grid) extends EntityContainer
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity): ScoreModification = {
+                      entity: Entity): (List[Entity], ScoreModification) = {
+    var entitiesReturn = List[Entity]()
     if (cell.mass > Virus.Mass * Cell.MassDominanceRatio) {
       logger.info(s"Player ${player.id}'s ${cell.id} (mass ${cell.mass}) ate a virus.")
 
       cell.mass = cell.mass * Virus.ImpactOnMass
+      entitiesReturn :::= List(entity)
       // TODO Split the cell ;)
     }
-    new ScoreModification(player.id, 0)
+    (entitiesReturn, new ScoreModification(player.id, 0))
   }
 
   def randomPosition(grid: Grid): Vector2 = {

--- a/game/src/main/scala/io/aigar/game/Virus.scala
+++ b/game/src/main/scala/io/aigar/game/Virus.scala
@@ -5,7 +5,6 @@ import com.typesafe.scalalogging.LazyLogging
 import com.github.jpbetz.subspace.Vector2
 import io.aigar.game.serializable.Position
 import io.aigar.score.ScoreModification
-import scala.collection.mutable.MutableList
 import io.aigar.game.Vector2Utils.Vector2Addons
 
 object Virus {
@@ -34,36 +33,33 @@ class Virus(var position: Vector2 = new Vector2(0f, 0f)) extends Entity {
 
 class Viruses(grid: Grid) extends EntityContainer
                           with LazyLogging {
-  val scoreModifications = MutableList[ScoreModification]()
+  var viruses = List.fill(Virus.Max)(new Virus(grid.randomPosition))
 
-  var viruses = List.fill(Virus.Max)(new Virus(grid.randomRadiusPosition))
+  def update(grid: Grid, players: List[Player]): List[ScoreModification] = {
+    val tupleReturn = handleCollision(viruses, players)
 
-  def update(grid: Grid, players: List[Player]): Unit = {
-    viruses = handleCollision(viruses, players, None).asInstanceOf[List[Virus]]
+    viruses = tupleReturn._1.asInstanceOf[List[Virus]]
+    val modifications = tupleReturn._2
 
     if (shouldRespawn(viruses.size, Virus.Min, Virus.Max)) {
       getRespawnPosition(grid, players, Virus.RespawnRetryAttempts) match {
-        case Some(position) => viruses :::= List(new Virus(position))
+        case Some(position) => viruses ::= new Virus(position)
         case _ =>
       }
     }
+    modifications
   }
 
   def onCellCollision(cell: Cell,
                       player: Player,
-                      entity: Entity,
-                      scoreModifications: Option[MutableList[ScoreModification]]): List[Entity] = {
-    var entityReturn = List[Entity]()
-
+                      entity: Entity): ScoreModification = {
     if (cell.mass > Virus.Mass * Cell.MassDominanceRatio) {
       logger.info(s"Player ${player.id}'s ${cell.id} (mass ${cell.mass}) ate a virus.")
 
       cell.mass = cell.mass * Virus.ImpactOnMass
       // TODO Split the cell ;)
-      entityReturn = List(entity)
     }
-    //Returns the entity to remove from the list
-    entityReturn
+    new ScoreModification(player.id, 0)
   }
 
   def randomPosition(grid: Grid): Vector2 = {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -4,6 +4,8 @@ import io.aigar.game.Vector2Utils._
 import io.aigar.controller.response.Action
 import org.scalatest._
 import com.github.jpbetz.subspace._
+import io.aigar.score.ScoreModification
+
 import scala.math._
 
 class CellSpec extends FlatSpec with Matchers {
@@ -319,10 +321,32 @@ class CellSpec extends FlatSpec with Matchers {
   "performAction" should "change target to match the one from the action" in {
     val player = new Player(0, Vector2(12f, 12f))
     val cell = player.cells.head
-    val grid = new Grid(100, 100);
 
     cell.performAction(Action(0, false, false, 0, Position(0f, 10f)))
 
     cell.target.state should equal(Position(0f, 10f))
+  }
+
+  "performAction" should "trade mass for score when mass is sufficient" in {
+    val player = new Player(1, Vector2(12f, 12f))
+    val cell = player.cells.head
+    val massToTrade = 11
+
+    cell.mass = Cell.MinMass + massToTrade
+    val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
+
+    modification.isEmpty shouldBe false
+    modification.get should equal(new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio))
+  }
+
+  "performAction" should "not trade mass for score when mass is insufficient" in {
+    val player = new Player(1, Vector2(12f, 12f))
+    val cell = player.cells.head
+    val massToTrade = 1
+
+    cell.mass = Cell.MinMass
+    val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
+
+    modification.isEmpty shouldBe true
   }
 }

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -253,27 +253,19 @@ class CellSpec extends FlatSpec with Matchers {
     val opponent = new Player(2, Vector2(10f, 10f))
     val largeCell = opponent.cells.head
 
-    largeCell.mass = 30
-    smallCell.mass = 26
+    largeCell.mass = Cell.MinMass * 2
+    smallCell.mass = Cell.MinMass
 
-    //The return is the entity to remove, hence the cell of the player if applicable
-    player.onCellCollision(opponent.cells.head, player, player.cells.head, None) should contain (smallCell.asInstanceOf[Entity])
+    player.cells = player.handleCollision(player.cells, List(opponent))._1.asInstanceOf[List[Cell]]
+
+    println(player.cells)
+    println(smallCell)
+
+    opponent.cells should contain(largeCell)
+    player.cells.isEmpty shouldBe true
   }
 
   it should "not be eaten by a cell between 90% to 100% of its mass" in {
-    val player = new Player(0, Vector2(10f, 10f))
-    val largeCell = player.cells.head
-    val opponent = new Player(2, Vector2(10f, 10f))
-    val smallCell = opponent.cells.head
-
-    largeCell.mass = Cell.MinMass + 1
-    smallCell.mass = Cell.MinMass
-
-    //The return is the entity to remove, hence the cell of the player if applicable
-    player.onCellCollision(opponent.cells.head, player, player.cells.head, None) shouldBe empty
-  }
-
-  it should "not be eaten by a smaller cell" in {
     val player = new Player(0, Vector2(10f, 10f))
     val smallCell = player.cells.head
     val opponent = new Player(2, Vector2(10f, 10f))
@@ -282,8 +274,23 @@ class CellSpec extends FlatSpec with Matchers {
     largeCell.mass = Cell.MinMass + 1
     smallCell.mass = Cell.MinMass
 
-    //The return is the entity to remove, hence the cell of the player if applicable
-    player.onCellCollision(opponent.cells.head, player, player.cells.head, None) shouldBe empty
+    player.handleCollision(player.cells, List(opponent))
+
+    player.cells should contain(smallCell)
+    opponent.cells should contain(largeCell)
+  }
+
+  it should "not be eaten by a smaller cell" in {
+    val player = new Player(0, Vector2(10f, 10f))
+    val largeCell = player.cells.head
+    val opponent = new Player(2, Vector2(10f, 10f))
+    val smallCell = opponent.cells.head
+
+    largeCell.mass = Cell.MinMass * 2
+    smallCell.mass = Cell.MinMass
+
+    player.cells should contain(largeCell)
+    opponent.cells should contain(smallCell)
   }
 
   it should "split into 2 cells with half the mass" in {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -339,7 +339,18 @@ class CellSpec extends FlatSpec with Matchers {
     modification.get should equal(new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio))
   }
 
-  "performAction" should "not trade mass for score when mass is insufficient" in {
+  it should "trade mass so that the cell keeps at least the minimal mass" in {
+    val player = new Player(1, Vector2(12f, 12f))
+    val cell = player.cells.head
+    val massToTrade = 100
+
+    cell.mass = Cell.MinMass + 10
+    val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
+
+    modification.get should equal(new ScoreModification(player.id, 10 * Cell.MassToScoreRatio))
+  }
+
+  it should "not trade mass for score when mass is insufficient" in {
     val player = new Player(1, Vector2(12f, 12f))
     val cell = player.cells.head
     val massToTrade = 1

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -258,11 +258,8 @@ class CellSpec extends FlatSpec with Matchers {
 
     player.cells = player.handleCollision(player.cells, List(opponent))._1.asInstanceOf[List[Cell]]
 
-    println(player.cells)
-    println(smallCell)
-
     opponent.cells should contain(largeCell)
-    player.cells.isEmpty shouldBe true
+    player.cells shouldBe empty
   }
 
   it should "not be eaten by a cell between 90% to 100% of its mass" in {
@@ -343,7 +340,7 @@ class CellSpec extends FlatSpec with Matchers {
     val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
 
     modification.isEmpty shouldBe false
-    modification.get should equal(new ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio))
+    modification.get should equal(ScoreModification(player.id, massToTrade * Cell.MassToScoreRatio))
   }
 
   it should "trade mass so that the cell keeps at least the minimal mass" in {
@@ -354,7 +351,7 @@ class CellSpec extends FlatSpec with Matchers {
     cell.mass = Cell.MinMass + 10
     val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
 
-    modification.get should equal(new ScoreModification(player.id, 10 * Cell.MassToScoreRatio))
+    modification.get should equal(ScoreModification(player.id, 10 * Cell.MassToScoreRatio))
   }
 
   it should "not trade mass for score when mass is insufficient" in {
@@ -365,6 +362,6 @@ class CellSpec extends FlatSpec with Matchers {
     cell.mass = Cell.MinMass
     val modification = cell.performAction(Action(cell.id, false, false, massToTrade, Position(0f, 10f)))
 
-    modification.isEmpty shouldBe true
+    modification shouldBe empty
   }
 }

--- a/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
@@ -111,8 +111,8 @@ class GameThreadSpec extends FlatSpec with Matchers with MockitoSugar {
     when(ranked.startTime).thenReturn(GameThread.time)
     when(ranked.duration).thenReturn(Int.MaxValue)
     when(notRanked.id).thenReturn(Game.RankedGameId + 1)
-    when(ranked.update(any[Float])).thenReturn(MutableList(ScoreModification(Game.RankedGameId, 1)))
-    when(notRanked.update(any[Float])).thenReturn(MutableList(ScoreModification(Game.RankedGameId + 1, 2)))
+    when(ranked.update(any[Float])).thenReturn(List(ScoreModification(Game.RankedGameId, 1)))
+    when(notRanked.update(any[Float])).thenReturn(List(ScoreModification(Game.RankedGameId + 1, 2)))
 
     game.updateGames
 

--- a/game/src/test/scala/io/aigar/game/ResourcesSpec.scala
+++ b/game/src/test/scala/io/aigar/game/ResourcesSpec.scala
@@ -100,9 +100,10 @@ class ResourcesSpec extends FlatSpec with Matchers {
       new Resource(p1.cells.head.position, Regular.Mass, Regular.Score),
       new Resource(p2.cells.head.position, Regular.Mass, Regular.Score))
 
-    val tupleReturn = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
+    val (resourcesReturn, modifications) = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
 
-    tupleReturn._1 shouldBe empty
+    resourcesReturn shouldBe empty
+    modifications should contain theSameElementsAs List(ScoreModification(p1.id, Regular.Score), ScoreModification(p2.id, Regular.Score))
   }
 
   it should "return the original list of entities when no collision occurs" in {
@@ -115,8 +116,9 @@ class ResourcesSpec extends FlatSpec with Matchers {
       new Resource(Vector2(25, 25), Regular.Mass, Regular.Score),
       new Resource(Vector2(30, 30), Regular.Mass, Regular.Score))
 
-    val tupleReturn = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
+    val (resourcesReturn, modifications) = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
 
-    tupleReturn._1 should contain theSameElementsAs resources.regulars.resources
+    resourcesReturn should contain theSameElementsAs resources.regulars.resources
+    modifications shouldBe empty
   }
 }

--- a/game/src/test/scala/io/aigar/game/ResourcesSpec.scala
+++ b/game/src/test/scala/io/aigar/game/ResourcesSpec.scala
@@ -3,7 +3,6 @@ package io.aigar.game
 import io.aigar.score._
 import com.github.jpbetz.subspace.Vector2
 import org.scalatest._
-import scala.collection.mutable.MutableList
 
 class ResourcesSpec extends FlatSpec with Matchers {
   "Resources" should "spawn at the right quantity" in {
@@ -101,12 +100,9 @@ class ResourcesSpec extends FlatSpec with Matchers {
       new Resource(p1.cells.head.position, Regular.Mass, Regular.Score),
       new Resource(p2.cells.head.position, Regular.Mass, Regular.Score))
 
-    val regularsReturn = resources.regulars.handleCollision(
-      resources.regulars.resources,
-      List(p1, p2),
-      Some(new MutableList[ScoreModification]()))
+    val tupleReturn = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
 
-    regularsReturn shouldBe empty
+    tupleReturn._1 shouldBe empty
   }
 
   it should "return the original list of entities when no collision occurs" in {
@@ -119,11 +115,8 @@ class ResourcesSpec extends FlatSpec with Matchers {
       new Resource(Vector2(25, 25), Regular.Mass, Regular.Score),
       new Resource(Vector2(30, 30), Regular.Mass, Regular.Score))
 
-    val regularsReturn = resources.regulars.handleCollision(
-      resources.regulars.resources,
-      List(p1, p2),
-      Some(new MutableList[ScoreModification]()))
+    val tupleReturn = resources.regulars.handleCollision(resources.regulars.resources, List(p1, p2))
 
-    regularsReturn should contain theSameElementsAs resources.regulars.resources
+    tupleReturn._1 should contain theSameElementsAs resources.regulars.resources
   }
 }

--- a/game/src/test/scala/io/aigar/game/VirusSpec.scala
+++ b/game/src/test/scala/io/aigar/game/VirusSpec.scala
@@ -24,7 +24,9 @@ class VirusSpec extends FlatSpec with Matchers {
 
     viruses.viruses = List(virus)
     // We make sure the cell is small enough so it doesn't eat the virus
-    cell.mass = Virus.Mass / Cell.MassDominanceRatio - 1
+    cell.mass = Virus.Mass * Cell.MassDominanceRatio - 1
+    println(cell.mass)
+    println(viruses.viruses.head.mass)
     player.cells = List(cell)
 
     viruses.update(new Grid(0, 0), List(player))


### PR DESCRIPTION
I've added the `MassToScore` ratio so we can decide later what it should be. It is currently 2 `mass `units for 1 `score` unit. 

Only the two last commits are relevant.

Closes #322 