### PR TITLE
Minimum Python requests version

### DIFF
--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests>=2.4.2
 planar


### PR DESCRIPTION
Since we're using the `json` parameter.