### PR TITLE
Adds error handling

### DIFF
--- a/web/src/javascript/gameWebWorker.js
+++ b/web/src/javascript/gameWebWorker.js
@@ -4,7 +4,10 @@ import {networkRefresh} from "./constants";
 async function updateLoop() {
   const startTime = (new Date()).getTime();
 
-  postMessage(await fetchState(0));
+  const result = await fetchState(0);
+  if(result) {
+    postMessage(result);
+  }
 
   const elapsed = (new Date()).getTime() - startTime;
   setTimeout(updateLoop, 1000/networkRefresh - elapsed);

--- a/web/src/javascript/network.js
+++ b/web/src/javascript/network.js
@@ -11,7 +11,8 @@ export function fetchState(gameId) {
     })
     .then(response => {
       return response.data;
-    });
+    })
+    .catch(error => console.error(error));
 }
 
 export function fetchLeaderboardEntries() {


### PR DESCRIPTION
Closes https://github.com/DrPandemic/aigar.io/issues/193

I don't think this is perfect. When we have server errors, it won't crash the client. When the connection come back up, the client start playing the game again.

But, there's a lot of errors in the client's logs.
![image](https://cloud.githubusercontent.com/assets/3250155/20449903/2abd2b1a-adba-11e6-907c-887d3c28328c.png)
The one about syntax could be simply ignored. It's coming from
```javascript
.catch(error => console.error(error));
```
But I think the other one is automatic and can not remove. Do you think I should remove the first and only keep the second one?