### PR TITLE
Silent the logs that are not part of the app

### DIFF
--- a/game/src/main/resources/logback.xml
+++ b/game/src/main/resources/logback.xml
@@ -14,6 +14,9 @@
         </encoder>
     </appender>
 
+    <logger name="com" level="OFF" />
+    <logger name="org" level="OFF" />
+
     <root level="info">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />


### PR DESCRIPTION
There [apparently](https://gist.github.com/traviskaufman/d13b29807c0be730db45) is a way to have a `logs` config only for tests to silent them while running the unit tests (by adding a `logback-test.xml` file in `src/test/resources`), but even then it would always prioritise the one in `/src/main/resources` when I tried it. We don't log that much and I definitely think that having those logs for the competition is a lot more important than having to scroll a tiny bit more to see a failing test.

If you want to silent them locally, you can always set the `root`'s log `level` to `OFF` and [ignore the local changes on git](http://stackoverflow.com/a/1753078/395386).