### PR TITLE
Get rid of max speed limit on velocity

### DIFF
--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -53,7 +53,7 @@ object Cell {
 }
 
 class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 0f)) extends Entity {
-  private var velocity = new Vector2(0f, 0f)
+  var velocity = new Vector2(0f, 0f)
   var target = position
   _mass = Cell.MinMass
   val scoreModification = 0

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -32,14 +32,37 @@ class CellSpec extends FlatSpec with Matchers {
     cell.velocity.magnitude should be > 0f
   }
 
-  it should "have a maximal velocity" in {
+  it should "not have a drag force with a small velocity" in {
     val player = new Player(0, Vector2(0f, 0f))
     val cell = player.cells.head
 
-    val hugeVelocity = new Vector2(1000f, 1000f)
+    val smallVelocity = new Vector2(1f, 0f)
+    cell.velocity = smallVelocity
+
+    cell.drag(1f).magnitude should equal(0f)
+  }
+
+  it should "have a drag force with a huge velocity" in {
+    val player = new Player(0, Vector2(0f, 0f))
+    val cell = player.cells.head
+
+    val hugeVelocity = new Vector2(100000f, 0f)
     cell.velocity = hugeVelocity
 
-    cell.velocity.magnitude should be < hugeVelocity.magnitude
+    cell.drag(1f).magnitude should be > 0f
+  }
+  
+  it should "apply a drag force with a huge velocity on update" in {
+    val player = new Player(0, Vector2(0f, 0f))
+    val cell = player.cells.head
+    val grid = new Grid(100000, 100000)
+
+    val hugeVelocity = new Vector2(1000f, 0f)
+    cell.velocity = hugeVelocity
+
+    cell.update(1f, grid)
+
+    cell.velocity.magnitude should be <(hugeVelocity.magnitude)
   }
 
   it should "move faster when it has a small mass" in {


### PR DESCRIPTION
Instead, we fake a "drag" force on the excess velocity. This will allow us to have "forces" applied to the cells (e.g. on split) and temporarily faster cells (e.g. on burst).

Precursor to #323 .