### PR TITLE
Burst

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -102,8 +102,8 @@ To eat an enemy cell, a cell must almost completely overlap its enemy and be
              The cell must be at least twice the minimum mass for this call to
              have an effect.
 
-- `burst()`: Exchanges a fixed amount of the cell's mass to gain a temporary
-             speed boost.
+- `burst()`: Exchanges a fixed amount (1) of the cell's mass to gain a
+             temporary speed boost.
              If the cell is too small to afford the price, this call has no
              effect.
 

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -73,6 +73,8 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
   _mass = Cell.MinMass
   val scoreModification = 0
 
+  var burstActive = false
+
   /**
    * The maximum speed (length of the velocity) for the cell, in units per
    * second.
@@ -99,6 +101,7 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     keepInGrid(grid)
 
     velocity += movement(deltaSeconds)
+    if (burstActive) applyBurst(deltaSeconds)
     velocity += drag(deltaSeconds)
   }
 
@@ -153,7 +156,12 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     if (mass < Cell.MinMass + Cell.BurstMassCost) return
 
     mass -= Cell.BurstMassCost
+    burstActive = true
+  }
+
+  def applyBurst(deltaSeconds: Float): Unit = {
     velocity += movement(Cell.BurstSecondsOfMovement)
+    burstActive = false
   }
 
   def split(): List[Cell] = {

--- a/game/src/main/scala/io/aigar/game/Cell.scala
+++ b/game/src/main/scala/io/aigar/game/Cell.scala
@@ -47,6 +47,20 @@ object Cell {
    */
   final val ExcessVelocityReductionPerSec = 0.25f
 
+  /**
+   * How much mass is required to gain a small burst of movement.
+   *
+   * IMPORTANT keep this value in sync with the client documentation
+   */
+  final val BurstMassCost = 1f
+
+  /**
+   * Bursting works by adding a certain amount of times the force that is
+   * normally applied when moving. This value controls how many "seconds" of
+   * movement force are added to the velocity on burst.
+   */
+  final val BurstSecondsOfMovement = 5f
+
   def radius(mass: Float): Float = {
     4f + sqrt(mass).toFloat * 3f
   }
@@ -84,7 +98,7 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     position += velocity * deltaSeconds
     keepInGrid(grid)
 
-    velocity += steering.truncate(maxSpeed) * deltaSeconds
+    velocity += movement(deltaSeconds)
     velocity += drag(deltaSeconds)
   }
 
@@ -122,12 +136,24 @@ class Cell(val id: Int, player: Player, var position: Vector2 = new Vector2(0f, 
     targetVelocity - velocity
   }
 
+  def movement(deltaSeconds: Float): Vector2 = {
+    steering.truncate(maxSpeed) * deltaSeconds
+  }
+
   def performAction(action: Action): Option[ScoreModification] = {
     target = action.target.toVector
 
     if (action.split) split
+    if (action.burst) burst
     val modifications = tradeMass(action.trade)
     modifications
+  }
+
+  def burst(): Unit = {
+    if (mass < Cell.MinMass + Cell.BurstMassCost) return
+
+    mass -= Cell.BurstMassCost
+    velocity += movement(Cell.BurstSecondsOfMovement)
   }
 
   def split(): List[Cell] = {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -388,7 +388,7 @@ class CellSpec extends FlatSpec with Matchers {
 
   it should "not burst when the cell is at its minimum mass" in {
     val player = new Player(0, Vector2(0f, 0f))
-    val cell = player.cell.head
+    val cell = player.cells.head
     cell.mass = Cell.MinMass
 
     cell.burstActive should equal(false)

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -386,6 +386,16 @@ class CellSpec extends FlatSpec with Matchers {
     bursting.velocity.magnitude should be > normal.velocity.magnitude
   }
 
+  it should "not burst when the cell is at its minimum mass" in {
+    val player = new Player(0, Vector2(0f, 0f))
+    val cell = player.cell.head
+    cell.mass = Cell.MinMass
+
+    cell.burstActive should equal(false)
+    cell.burst()
+    cell.burstActive should equal(true)
+  }
+
   "performAction" should "change target to match the one from the action" in {
     val player = new Player(0, Vector2(12f, 12f))
     val cell = player.cells.head

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -369,8 +369,8 @@ class CellSpec extends FlatSpec with Matchers {
   "Burst" should "give a velocity boost on update" in {
     val grid = new Grid(1000, 1000)
     val player = new Player(0, Vector2(0f, 0f))
-    val bursting = new Cell(1, player, Vector2(0f, 100f))
-    val normal = new Cell(2, player, Vector2(0f, 0f))
+    val bursting = new Cell(1, player, Vector2(1f, 100f))
+    val normal = new Cell(2, player, Vector2(1f, 1f))
     player.cells = List(bursting, normal)
     bursting.mass += 10 // give enough mass to afford a burst
     normal.mass += 10 // share the same mass to be comparable

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -357,13 +357,33 @@ class CellSpec extends FlatSpec with Matchers {
     cells should contain(cell)
   }
 
-    it should "returns a list with only itself when the split didn't work" in {
+  it should "returns a list with only itself when the split didn't work" in {
     val player = new Player(0, Vector2(0f, 0f))
     player.cells = List.fill(Player.MaxCells)(player.spawnCell(Vector2(0f, 0f)))
 
     val cells = player.cells.head.split
 
     cells should contain only(player.cells.head)
+  }
+
+  "Burst" should "give a velocity boost on update" in {
+    val grid = new Grid(1000, 1000)
+    val player = new Player(0, Vector2(0f, 0f))
+    val bursting = new Cell(1, player, Vector2(0f, 100f))
+    val normal = new Cell(2, player, Vector2(0f, 0f))
+    player.cells = List(bursting, normal)
+    bursting.mass += 10 // give enough mass to afford a burst
+    normal.mass += 10 // share the same mass to be comparable
+    bursting.target = Vector2(100f, 100f)
+    normal.target = Vector2(100f, 0f)
+
+    player.update(1f, grid, List())
+    bursting.velocity.magnitude should equal(normal.velocity.magnitude)
+
+    bursting.burst()
+    player.update(1f, grid, List())
+
+    bursting.velocity.magnitude should be > normal.velocity.magnitude
   }
 
   "performAction" should "change target to match the one from the action" in {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -376,12 +376,16 @@ class CellSpec extends FlatSpec with Matchers {
     normal.mass += 10 // share the same mass to be comparable
     bursting.target = Vector2(100f, 100f)
     normal.target = Vector2(100f, 0f)
+    bursting.aiState = new NullState(bursting)
+    normal.aiState = new NullState(normal)
 
-    player.update(1f, grid, List())
-    bursting.velocity.magnitude should equal(normal.velocity.magnitude)
+    player.update(0.5f, grid, List())
+    bursting.velocity.magnitude should be > 0f
+    normal.velocity.magnitude should be > 0f
+    bursting.velocity.magnitude should equal(normal.velocity.magnitude +- 0.002f)
 
     bursting.burst()
-    player.update(1f, grid, List())
+    player.update(0.5f, grid, List())
 
     bursting.velocity.magnitude should be > normal.velocity.magnitude
   }
@@ -391,9 +395,8 @@ class CellSpec extends FlatSpec with Matchers {
     val cell = player.cells.head
     cell.mass = Cell.MinMass
 
-    cell.burstActive should equal(false)
     cell.burst()
-    cell.burstActive should equal(true)
+    cell.burstActive should equal(false)
   }
 
   "performAction" should "change target to match the one from the action" in {

--- a/game/src/test/scala/io/aigar/game/CellSpec.scala
+++ b/game/src/test/scala/io/aigar/game/CellSpec.scala
@@ -52,7 +52,7 @@ class CellSpec extends FlatSpec with Matchers {
 
     cell.drag(1f).magnitude should be > 0f
   }
-  
+
   it should "apply a drag force with a huge velocity on update" in {
     val player = new Player(0, Vector2(0f, 0f))
     val cell = player.cells.head


### PR DESCRIPTION
Closes #323 .

If you want to see an AI that uses this to chase down close enemies, come see me IRL (I don't want to  commit it because I feel like it's starting to look a bit too much like what participants could implement).

Note that the "5 seconds of movement applied" here will *not* move the cell *as if* it had moved for 5 seconds. It's adding the equivalent of 5 seconds of movement *velocity* to the `velocity` of the cell. How that affects movement is controlled by how the `drag` is handled (see #363), so balancing this is a bit more subtle (in other words: it will add *excess* velocity, which is then progressively penalised by the `drag` logic).

It's hard to say if it is balanced right now, but I noticed some important things:
1. Always having it on is not reliable (with the AI that collects only resources it would almost always stay at `20`)
2. Having it on to chase another cell doesn't look *that* overpowered from my experiments (though that's hard to evaluate against dumb AIs...)
3. I'm not sure if it's *good enough* to be used at the moment, but that's hard to tell with dumb AIs, once again.