### PR TITLE
Fix multiple games

### DIFF
--- a/game/src/main/scala/io/aigar/game/Game.scala
+++ b/game/src/main/scala/io/aigar/game/Game.scala
@@ -1,5 +1,6 @@
 package io.aigar.game
 
+import scala.math.round
 import com.github.jpbetz.subspace.Vector2
 import com.typesafe.scalalogging.LazyLogging
 import io.aigar.score.ScoreModification
@@ -14,6 +15,20 @@ object Game {
   final val DefaultDuration = 60 * 20
   final val PrivateGameDuration = 60 * 10
   final val PrivateGameBotQuantity = 5
+
+  final val NanoSecondsPerMillisecond = 1000000f
+  final val MillisecondsPerSecond = 1000f
+  final val NanoSecondsPerSecond = NanoSecondsPerMillisecond * MillisecondsPerSecond
+
+  final val TicksPerSecond = 15
+  final val MillisecondsPerTick = round(MillisecondsPerSecond / TicksPerSecond)
+
+  /**
+    * Current time, in seconds.
+    */
+  def time: Float = {
+    System.nanoTime / NanoSecondsPerSecond
+  }
 }
 
 class Game(val id: Int,
@@ -26,15 +41,20 @@ class Game(val id: Int,
   val players = createPlayers
   val viruses = new Viruses(grid)
   val resources = new Resources(grid)
-  val startTime = GameThread.time
+  val startTime = Game.time
+  var previousTime = 0f
+  var currentTime = Game.MillisecondsPerTick / Game.MillisecondsPerSecond // avoid having an initial 0 delta time
   var tick = 0
 
-  def update(deltaSeconds: Float): List[ScoreModification] = {
+  def update: List[ScoreModification] = {
+    val deltaSeconds = currentTime - previousTime
     var modifications = players.flatten {  _.update(deltaSeconds, grid, players) }
     modifications :::= viruses.update(grid, players)
     modifications :::= resources.update(grid, players)
     tick += 1
 
+    previousTime = currentTime
+    currentTime = Game.time
     modifications
   }
 
@@ -49,16 +69,15 @@ class Game(val id: Int,
     modifications
   }
 
-  def time: Float = {
-    duration - (GameThread.time - startTime)
+  def timeLeft: Float = {
+    duration - (Game.time - startTime)
   }
 
   def state: serializable.GameState = {
-    //TODO really implement and update spec to add tests
     serializable.GameState(
         id,
         tick,
-        time,
+        timeLeft,
         players.map(_.state),
         resources.state,
         grid.state,

--- a/game/src/main/scala/io/aigar/game/GameThread.scala
+++ b/game/src/main/scala/io/aigar/game/GameThread.scala
@@ -1,9 +1,12 @@
 package io.aigar.game
 
 import com.typesafe.scalalogging.LazyLogging
-import io.aigar.controller.response.GameCreationCommand
-import scala.math.round
-import io.aigar.controller.response.{AdminCommand, SetRankedDurationCommand, RestartThreadCommand}
+import io.aigar.controller.response.{
+  AdminCommand,
+  GameCreationCommand,
+  SetRankedDurationCommand,
+  RestartThreadCommand
+}
 import io.aigar.score.{ScoreModification, ScoreThread}
 import java.util.concurrent.LinkedBlockingQueue
 
@@ -12,22 +15,6 @@ import java.util.concurrent.LinkedBlockingQueue
  * takes care of updating the individual games and processing the queued inputs
  * of the players.
  */
-object GameThread {
-  final val NanoSecondsPerMillisecond = 1000000f
-  final val MillisecondsPerSecond = 1000f
-  final val NanoSecondsPerSecond = NanoSecondsPerMillisecond * MillisecondsPerSecond
-
-  final val TicksPerSecond = 15
-  final val MillisecondsPerTick = round(MillisecondsPerSecond / TicksPerSecond)
-
-  /**
-    * Current time, in seconds.
-    */
-  def time: Float = {
-    System.nanoTime / NanoSecondsPerSecond
-  }
-}
-
 class GameThread(scoreThread: ScoreThread) extends Runnable
                                            with LazyLogging {
   logger.info("Starting Game thread.")
@@ -43,8 +30,6 @@ class GameThread(scoreThread: ScoreThread) extends Runnable
 
   var running = true
   var started = false
-  var previousTime = 0f
-  var currentTime = GameThread.MillisecondsPerTick / GameThread.MillisecondsPerSecond // avoid having an initial 0 delta time
 
   def restart(playerIDs: List[Int]): Unit = {
     actionQueue.clear
@@ -75,12 +60,12 @@ class GameThread(scoreThread: ScoreThread) extends Runnable
   def run: Unit = {
     while (running) {
       transferAdminCommands
-      if(started) {
+      if (started) {
         transferActions
         updateGames
       }
 
-      Thread.sleep(GameThread.MillisecondsPerTick)
+      Thread.sleep(Game.MillisecondsPerTick)
     }
   }
 
@@ -98,7 +83,7 @@ class GameThread(scoreThread: ScoreThread) extends Runnable
   }
 
   def transferAdminCommands: Unit = {
-    while(!adminCommandQueue.isEmpty) {
+    while (!adminCommandQueue.isEmpty) {
       adminCommandQueue.take match {
         case command: SetRankedDurationCommand => nextRankedDuration = command.duration
         case command: RestartThreadCommand => restart(command.playerIDs)
@@ -110,8 +95,8 @@ class GameThread(scoreThread: ScoreThread) extends Runnable
   private def resetRankedGameIfExpired: Unit = {
     games.get(Game.RankedGameId) match {
       case Some(ranked) => {
-        val elapsed = GameThread.time - ranked.startTime
-        if(ranked.duration < elapsed) {
+        val elapsed = Game.time - ranked.startTime
+        if (ranked.duration < elapsed) {
           games = games - Game.RankedGameId
           games = games + (Game.RankedGameId -> createRankedGame)
         }
@@ -124,20 +109,14 @@ class GameThread(scoreThread: ScoreThread) extends Runnable
     resetRankedGameIfExpired
 
     for (game <- games.values) {
-      val deltaTime = currentTime - previousTime
-      val modifications = game.update(deltaTime)
+      val modifications = game.update
       applyScoreModifications(game, modifications)
-
-      game.update(deltaTime)
       states = states + (game.id -> game.state)
-
-      previousTime = currentTime
-      currentTime = GameThread.time
     }
   }
 
   def applyScoreModifications(game: Game, modifications: List[ScoreModification]): Unit = {
-    if(game.id == Game.RankedGameId) {
+    if (game.id == Game.RankedGameId) {
       modifications.foreach { scoreThread.addScoreModification(_) }
     }
   }

--- a/game/src/test/scala/io/aigar/game/GameSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameSpec.scala
@@ -1,9 +1,9 @@
 import io.aigar.controller.response.Action
-import io.aigar.game._
-import io.aigar.score.ScoreModification
+import io.aigar.game.{Game, NullState, Regular, Resource, Virus}
 import io.aigar.game.serializable.Position
-import org.scalatest._
-import com.github.jpbetz.subspace._
+import io.aigar.score.ScoreModification
+import org.scalatest.{FlatSpec, Matchers}
+import com.github.jpbetz.subspace.Vector2
 
 class GameSpec extends FlatSpec with Matchers {
   "A Game" should "generate a new state object every time (thread-safety)" in {
@@ -16,7 +16,7 @@ class GameSpec extends FlatSpec with Matchers {
     val game = new Game(42, List())
     game.tick should equal(0)
 
-    game.update(1f)
+    game.update
 
     game.tick should equal(1)
   }
@@ -53,7 +53,7 @@ class GameSpec extends FlatSpec with Matchers {
     cell.position = Vector2(0, 0)
     cell.target = new Vector2(100f, 100f)
 
-    game.update(1f)
+    game.update
 
     cell.velocity.magnitude should be > 0f
   }
@@ -85,7 +85,10 @@ class GameSpec extends FlatSpec with Matchers {
     player.cells.head.target = Vector2(40, 0)
     player.cells.head.aiState = new NullState(player.cells.head)
 
-    val resourceModifications = game.update(0f)
+    // This is to ensure no movement
+    game.currentTime = 0
+    game.previousTime = 0
+    val resourceModifications = game.update
 
     resourceModifications should contain (ScoreModification(player.id, Regular.Score))
   }

--- a/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
+++ b/game/src/test/scala/io/aigar/game/GameThreadSpec.scala
@@ -1,13 +1,13 @@
-import io.aigar.game._
 import io.aigar.controller.response.GameCreationCommand
 import io.aigar.controller.response.{SetRankedDurationCommand, RestartThreadCommand}
+import io.aigar.game.{ActionQueryWithId, Game, GameThread}
 import io.aigar.score.{ScoreModification, ScoreThread}
 import io.aigar.controller.response.Action
 import io.aigar.game.serializable.Position
-import org.scalatest._
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.Mockito.{verify, when}
+import org.mockito.Matchers.any
 
 class GameThreadSpec extends FlatSpec with Matchers with MockitoSugar {
   def createStartedGameThread(playerIDs: List[Int] = List()): GameThread = {
@@ -199,11 +199,11 @@ class GameThreadSpec extends FlatSpec with Matchers with MockitoSugar {
     val notRanked = mock[Game]
     game.games = Map(Game.RankedGameId -> ranked, Game.RankedGameId + 1 -> notRanked)
     when(ranked.id).thenReturn(Game.RankedGameId)
-    when(ranked.startTime).thenReturn(GameThread.time)
+    when(ranked.startTime).thenReturn(Game.time)
     when(ranked.duration).thenReturn(Int.MaxValue)
     when(notRanked.id).thenReturn(Game.RankedGameId + 1)
-    when(ranked.update(any[Float])).thenReturn(List(ScoreModification(Game.RankedGameId, 1)))
-    when(notRanked.update(any[Float])).thenReturn(List(ScoreModification(Game.RankedGameId + 1, 2)))
+    when(ranked.update).thenReturn(List(ScoreModification(Game.RankedGameId, 1)))
+    when(notRanked.update).thenReturn(List(ScoreModification(Game.RankedGameId + 1, 2)))
 
     game.updateGames
 


### PR DESCRIPTION
Closes https://github.com/DrPandemic/aigar.io/issues/396

I moved the time delta calculation to the game object.

Also, we always called update twice on every update...
```scala
      val modifications = game.update(deltaTime)		
      applyScoreModifications(game, modifications)
      game.update(deltaTime)
```
So, now that's fixed the game feel much slower. Maybe we should change some numbers.