### PR TITLE
Recreates the AI class after a game reset

### DIFF
--- a/clients/python/game/game_loop.py
+++ b/clients/python/game/game_loop.py
@@ -1,16 +1,13 @@
-def update_game(api, game_id, step_fn):
+def update_game(api, game, step_fn):
     """
     Takes care of doing one update tick:
-    - fetch the game state
     - call the player's AI
     - send actions chosen by AI
 
-    :param api: API object to communicate with the server
-    :param game_id: ID of the game that we're playing
+    :param api:     API object to communicate with the server
+    :param game:    The current game's state.
     :param step_fn: function to call to execute the player's AI
     """
-    game = api.fetch_game_state(game_id)
-
     step_fn(game)
 
-    api.send_actions(game_id, [cell.actions() for cell in game.me.cells])
+    api.send_actions(game.id, [cell.actions() for cell in game.me.cells])

--- a/clients/python/game/game_loop_test.py
+++ b/clients/python/game/game_loop_test.py
@@ -19,15 +19,12 @@ class GameLoopTests(TestCase):
         cells[1].trade(3)
 
         class MockApi:
-            def fetch_game_state(self, game_id):
-                return game
-
             def send_actions(self, game_id, actions):
                 self.actions = actions
 
         api = MockApi()
 
-        update_game(api, 0, lambda x: None)
+        update_game(api, game, lambda x: None)
 
         self.assertTrue(
             api.actions[0].target.almost_equals(Vec2(2, 2)))

--- a/clients/python/play.py
+++ b/clients/python/play.py
@@ -18,6 +18,7 @@ def main():
     player_id, player_secret, api_url = read_config()
     game_id = player_id if join_private else Game.RANKED_GAME_ID
     api = API(player_id, player_secret, api_url)
+    previous_tick = -1
     ai = AI()
 
     if(create_private):
@@ -26,7 +27,13 @@ def main():
         sleep(0.5)
 
     while True:
-        update_game(api, game_id, ai.step)
+        game = api.fetch_game_state(game_id)
+
+        if(game.tick < previous_tick):  # After a game reset, it reinstanciates the AI object
+            ai = AI()
+        previous_tick = game.tick
+
+        update_game(api, game, ai.step)
 
         sleep(1 / UpdatesPerSecond)
 


### PR DESCRIPTION
Closes https://github.com/DrPandemic/aigar.io/issues/421

The fetching logic was moved out from `update_game` to be able to determine when to reset the AI. What do you think about that?