### PR TITLE
Adds instruction to download and not compile planar on windows

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -3,8 +3,18 @@
 - Python 3
 
 ## Setup
+### Linux
 1. `pip install -r ./requirements.txt`
 2. Rename `player.default.json` to `player.json` and replace
+   `player_id`, `player_secret` and `api_url` by the values that were given to you by the
+   organisers
+
+### Windows
+1. Download and extract the planar library at
+`https://bitbucket.org/caseman/planar/get/9f8615991edd.zip`
+2. Go into the `planar` folder and run `python setup.py build_py install --skip-build`
+3. `pip install 'requests>=2.4.2'`
+4. Rename `player.default.json` to `player.json` and replace
    `player_id`, `player_secret` and `api_url` by the values that were given to you by the
    organisers
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -12,11 +12,11 @@
 ### Windows
 1. Download and extract the planar library at
 `https://bitbucket.org/caseman/planar/get/9f8615991edd.zip`
-2. Go into the `planar` folder and run `python setup.py build_py install --skip-build`
-3. `pip install 'requests>=2.4.2'`
-4. Rename `player.default.json` to `player.json` and replace
-   `player_id`, `player_secret` and `api_url` by the values that were given to you by the
-   organisers
+2. Go into the extracted folder and run `python setup.py build_py install --skip-build`
+3. `pip install "requests>=2.4.2"`
+4. In the Aigar.io project folder, rename `player.default.json` to `player.json` and
+   replace `player_id`, `player_secret` and `api_url` by the values that were given to
+   you by the organisers
 
 ## Joining the Ranked Game
 `python ./play.py`


### PR DESCRIPTION
Closes https://github.com/DrPandemic/aigar.io/issues/320

Planar has a version that doesn't require to be built. This explain how to install it.

Could someone on windows test this please? To do it `pip uninstall planar` and follow the new instructions.